### PR TITLE
Add CVM probe

### DIFF
--- a/src/characterization/config/probing/cvm.yaml
+++ b/src/characterization/config/probing/cvm.yaml
@@ -1,0 +1,5 @@
+defaults:
+  - default
+
+# Probe type to apply; must match a ProbeType enum name.
+probe_type: CONSTANT_VELOCITY

--- a/src/characterization/config/probing/default.yaml
+++ b/src/characterization/config/probing/default.yaml
@@ -1,0 +1,18 @@
+# Counterfactual probing parameters (common defaults for all probe types).
+
+# Minimum interaction pair-score increase required for a probe to be considered impactful.
+min_score_delta: 0.2
+
+# Feature aggregation strategy used when computing pair features: "critical" or "average".
+return_criterion: critical
+
+# Number of parallel workers for pair-level computation inside the prober. Set to 1 when running multiple scenarios in
+# parallel (num_workers > 1 in the entrypoint) to avoid nested processes.
+n_jobs: 1
+
+# Agent types to exclude from probing (list of AgentType enum names, e.g. ["TYPE_UNSET"]).
+skip_agent_types: []
+
+# When true, keep only the single most-critical affected agent in the returned CriticalProbe (TTC beats DRAC; among
+# equal metrics, earliest timestamp wins).
+single_affected_agent: true

--- a/src/characterization/probing/common.py
+++ b/src/characterization/probing/common.py
@@ -1,0 +1,16 @@
+"""Shared enumerations for counterfactual scenario probing."""
+
+from enum import Enum, StrEnum
+
+
+class ProbeValidity(Enum):
+    """Validity of a counterfactual probe trajectory."""
+
+    VALID = "VALID"
+    INVALID = "INVALID"
+
+
+class ProbeType(StrEnum):
+    """Type of counterfactual probe applied to an agent."""
+
+    CONSTANT_VELOCITY = "CONSTANT_VELOCITY"

--- a/src/characterization/probing/counterfactual_probes/constant_velocity_model.py
+++ b/src/characterization/probing/counterfactual_probes/constant_velocity_model.py
@@ -1,0 +1,73 @@
+"""Constant-velocity counterfactual probe for autonomous driving scenarios.
+
+Replaces an agent's future trajectory (frames after ``current_time_index``) with a straight-line constant-velocity
+extrapolation anchored at the last valid observed state.
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from characterization.probing.common import ProbeValidity
+from characterization.utils.common import AgentTrajectoryMasker
+
+_STATIONARY_SPEED_THRESHOLD = 1e-4  # m/s — below this the probe is considered invalid
+
+
+def constant_velocity_probe(
+    trajectory: AgentTrajectoryMasker,
+    current_time_index: int,
+    frequency_hz: float,
+) -> tuple[NDArray[np.float32], ProbeValidity]:
+    """Replace future frames with a constant-velocity extrapolation anchored at the last valid state.
+
+    The probe is computed as follows:
+    1. Find the last valid frame at or before ``current_time_index``.
+    2. Compute per-step displacement from the stored (vx, vy) velocity and ``frequency_hz``.
+    3. If displacement is (near) zero, return ``ProbeValidity.INVALID``.
+    4. Fill all future frames by accumulating integer multiples of the displacement from the reference position. Heading
+    and velocity are held constant; all future frames are marked valid.
+
+    Args:
+        trajectory: Single-agent trajectory wrapped in ``AgentTrajectoryMasker`` (underlying shape ``(T, 10)``).
+            Modified on a copy — the original is not mutated.
+        current_time_index: Index of the last observed frame (inclusive). Future frames start at
+            ``current_time_index + 1``.
+        frequency_hz: Sampling frequency in Hz, used to convert velocity to per-step displacement.
+
+    Returns:
+        ``(modified_trajectory, ProbeValidity.VALID)`` if the agent is moving, or
+        ``(original_trajectory, ProbeValidity.INVALID)`` if the agent is stationary.
+    """
+    raw = trajectory.agent_trajectories
+    num_timesteps = raw.shape[0]
+
+    # Find the last valid observed frame at or before current_time_index.
+    valid_flags = trajectory.agent_valid[: current_time_index + 1, 0]
+    valid_indices = np.where(valid_flags > 0)[0]
+    if len(valid_indices) == 0:
+        return raw, ProbeValidity.INVALID
+    ref_idx = int(valid_indices[-1])
+
+    ref_vel = trajectory.agent_xy_vel[ref_idx]  # shape (2,): [vx, vy]
+    vx, vy = float(ref_vel[0]), float(ref_vel[1])
+
+    dt = 1.0 / frequency_hz
+    dx = vx * dt
+    dy = vy * dt
+
+    if abs(dx) < _STATIONARY_SPEED_THRESHOLD * dt and abs(dy) < _STATIONARY_SPEED_THRESHOLD * dt:
+        return raw, ProbeValidity.INVALID
+
+    perturbed = raw.copy()
+    ref_xyz = trajectory.agent_xyz_pos[ref_idx]  # shape (3,): [x, y, z]
+    ref_heading = trajectory.agent_headings[ref_idx]  # shape (1,)
+
+    future_start = current_time_index + 1
+    for t in range(future_start, num_timesteps):
+        steps = t - ref_idx
+        perturbed[t][trajectory.xyz_pos_mask] = [ref_xyz[0] + steps * dx, ref_xyz[1] + steps * dy, ref_xyz[2]]
+        perturbed[t][trajectory.heading_mask] = ref_heading
+        perturbed[t][trajectory.xy_vel_mask] = ref_vel
+        perturbed[t][trajectory.valid_mask] = 1.0
+
+    return perturbed, ProbeValidity.VALID

--- a/src/characterization/utils/common.py
+++ b/src/characterization/utils/common.py
@@ -192,6 +192,11 @@ class AgentTrajectoryMasker:
         """Mask for the heading feature."""
         return self._TRAJECTORY_HEADING
 
+    @property
+    def valid_mask(self) -> list[bool]:
+        """Mask for the valid flag feature."""
+        return self._TRAJECTORY_VALID
+
     # Trajectory accessors
     @property
     def agent_trajectories(self) -> NDArray[np.float32]:


### PR DESCRIPTION
This pull request introduces a new constant-velocity counterfactual probe for autonomous driving scenario analysis, along with supporting configuration, enums, and utility enhancements. The main focus is on enabling and configuring a probe that replaces future agent trajectories with a straight-line extrapolation at constant velocity, anchored to the last valid observed state.

Key changes include:

**New Probe Implementation:**

* Added the `constant_velocity_probe` function in `constant_velocity_model.py`, which generates future agent trajectories by linearly extrapolating the last valid velocity and position, and marks the probe as valid or invalid based on agent movement.

**Enumerations and Shared Types:**

* Introduced `ProbeValidity` and `ProbeType` enums in `common.py` to standardize probe types and validity status across the codebase.

**Configuration Enhancements:**

* Added `cvm.yaml` to configure the constant-velocity probe, specifying the probe type and inheriting defaults.
* Created `default.yaml` with common counterfactual probing parameters, such as minimum score delta, aggregation strategy, parallelism, agent exclusions, and affected agent selection.

**Utility Improvements:**

* Added a `valid_mask` property to `AgentTrajectoryMasker` in `common.py` to facilitate access to the valid flag feature, supporting the new probe logic.