### PR TITLE
Add categorical pane and support for all pane visualizations

### DIFF
--- a/src/characterization/config/viz/all_panes_scenario.yaml
+++ b/src/characterization/config/viz/all_panes_scenario.yaml
@@ -1,0 +1,9 @@
+defaults:
+  - probe_scenario.yaml
+
+config:
+  panes_to_plot:
+    - ALL_AGENTS
+    - HIGHLIGHT_RELEVANT_AGENTS
+    - COUNTERFACTUAL_PROBE
+    - CATEGORICAL_AGENTS

--- a/src/characterization/config/viz/categorical_scenario.yaml
+++ b/src/characterization/config/viz/categorical_scenario.yaml
@@ -3,4 +3,5 @@ defaults:
 
 _target_: characterization.utils.viz.scenario.ScenarioVisualizer
 config:
-  plot_categorical: true
+  panes_to_plot:
+    - CATEGORICAL_AGENTS

--- a/src/characterization/config/viz/probe_scenario.yaml
+++ b/src/characterization/config/viz/probe_scenario.yaml
@@ -1,3 +1,6 @@
+defaults:
+ - scenario.yaml
+
 _target_: characterization.utils.viz.scenario.ScenarioVisualizer
 config:
   scenario_type: ${scenario_type}
@@ -17,8 +20,8 @@ config:
   # Gap line between probed and affected agent at criticality timestamp.
   # Draws a diamond on the counterfactual trajectory and a dotted line to the affected agent,
   # showing exactly how far apart both agents were *at the same moment in time*.
-  show_criticality_gap: true
-  show_gap_distance: true
+  show_criticality_gap: false
+  show_gap_distance: false
   gap_line_color: "crimson"
   gap_marker_size: 30
 

--- a/src/characterization/run_scenario_viz.py
+++ b/src/characterization/run_scenario_viz.py
@@ -1,14 +1,24 @@
 """Entrypoint for visualizing scenarios, optionally organized by score percentile.
 
-Loads scenario pickle files, optionally filters to those with precomputed scores, groups them into score-percentile
-subdirectories, and renders visualizations using the configured dataset and visualizer. Configuration is loaded from
-``config/run_analysis.yaml`` by default.
+Loads scenario pickle files, optionally filters to those with precomputed scores or probed scenarios, groups them into
+score-percentile subdirectories, and renders visualizations using the configured dataset and visualizer. Configuration
+is loaded from ``config/run_analysis.yaml`` by default.
+
+The active viz config's ``panes_to_plot`` drives data loading automatically:
+
+* ``COUNTERFACTUAL_PROBE`` in panes → scenarios are loaded from ``probed_scenarios_path`` (output of
+  :class:`~characterization.processors.probe_processor.ProbeProcessor`), which embeds the probe in the
+  :class:`~characterization.schemas.Scenario` object.
+* ``CATEGORICAL_AGENTS`` in panes → per-scenario :class:`~characterization.schemas.ScenarioScores` are loaded from
+  ``scores_path`` and passed to the visualizer.
 
 Example usage::
 
     uv run python -m characterization.run_scenario_viz
     uv run python -m characterization.run_scenario_viz score_to_visualize=individual total_scenarios=50
-    uv run python -m characterization.run_scenario_viz organize_by_percentile=true viz_scored_scenarios=true
+    uv run python -m characterization.run_scenario_viz organize_by_percentile=true viz=categorical_scenario
+    uv run python -m characterization.run_scenario_viz scenario_id=<scene_id>
+    uv run python -m characterization.run_scenario_viz viz=all_panes_scenario total_scenarios=5
 """
 
 import copy
@@ -21,11 +31,39 @@ import numpy as np
 import pandas as pd
 from omegaconf import DictConfig
 
-from characterization.schemas import ScenarioScores
+from characterization.schemas import Scenario, ScenarioScores, Score
 from characterization.utils.io_utils import from_pickle, get_logger
 from characterization.utils.viz.visualizer import BaseVisualizer
 
 logger = get_logger(__name__)
+
+# Maps score_to_visualize values to the attribute name on ScenarioScores.
+_SCORE_ATTR: dict[str, str] = {
+    "individual": "individual_scores",
+    "interaction": "interaction_scores",
+    "safeshift": "safeshift_scores",
+}
+
+# Maps score_to_visualize values to their corresponding ground-truth categories file name.
+_CATEGORIES_FILENAME: dict[str, str] = {
+    "individual": "gt_critical_categorical_individual.json",
+    "interaction": "gt_critical_categorical_interaction.json",
+    "safeshift": "gt_critical_categorical_safeshift.json",
+}
+
+
+def _select_scores(scenario_scores: ScenarioScores, score_to_visualize: str) -> Score | None:
+    """Return the appropriate :class:`Score` field from *scenario_scores* based on *score_to_visualize*.
+
+    Args:
+        scenario_scores: Validated :class:`ScenarioScores` object.
+        score_to_visualize: One of ``"individual"``, ``"interaction"``, or ``"safeshift"``.
+
+    Returns:
+        The selected :class:`Score`, or ``None`` if *score_to_visualize* is not recognised.
+    """
+    attr = _SCORE_ATTR.get(score_to_visualize)
+    return getattr(scenario_scores, attr) if attr is not None else None
 
 
 def _organize_scenarios_by_percentile(
@@ -85,6 +123,26 @@ def _organize_scenarios_by_percentile(
     return scenario_output_dirs
 
 
+def _get_probed_filepaths(cfg: DictConfig) -> list[Path] | None:
+    """Load probed scenario filepaths from ``cfg.probed_scenarios_path``, filtering by ``cfg.scenario_id`` if set.
+
+    Returns the list of paths, or ``None`` if the directory does not exist or a requested scenario is not found.
+    """
+    probed_path = Path(cfg.probed_scenarios_path)
+    if not probed_path.exists():
+        logger.error("Probed scenarios directory '%s' does not exist.", probed_path)
+        return None
+    filepaths = list(probed_path.glob("*.pkl"))
+    logger.info("Loading %d probed scenarios from %s", len(filepaths), probed_path)
+    if cfg.scenario_id:
+        filepaths = [fp for fp in filepaths if fp.stem == cfg.scenario_id]
+        if not filepaths:
+            logger.error("No probed scenario found with ID '%s' under %s", cfg.scenario_id, probed_path)
+            return None
+        logger.info("Filtering to single probed scenario: %s", cfg.scenario_id)
+    return filepaths
+
+
 @hydra.main(config_path="config", config_name="run_analysis", version_base="1.3")
 def run(cfg: DictConfig) -> None:
     """Runs the scenario visualization pipeline using the provided configuration.
@@ -101,6 +159,11 @@ def run(cfg: DictConfig) -> None:
     scenario_viz_dir = Path(cfg.scenario_viz_dir) / f"{date}{cfg.scores_tag}_{cfg.score_to_visualize}"
     scenario_viz_dir.mkdir(parents=True, exist_ok=True)
 
+    # Derive data-loading behaviour from the active viz config's panes_to_plot.
+    panes_to_plot = list(cfg.viz.config.get("panes_to_plot", ["ALL_AGENTS"]))
+    viz_probed_scenarios = "COUNTERFACTUAL_PROBE" in panes_to_plot
+    viz_scored_scenarios = "CATEGORICAL_AGENTS" in panes_to_plot
+
     # Instantiate dataset and visualizer
     cfg.dataset.config.load = False
     logger.info("Instatiating dataset: %s", cfg.dataset._target_)
@@ -110,22 +173,27 @@ def run(cfg: DictConfig) -> None:
     scenario_filepaths = list(scenario_base_path.rglob("*.pkl"))
     scores_path = Path(cfg.scores_path) / cfg.scores_tag
 
+    if cfg.scenario_id and not viz_probed_scenarios:
+        scenario_filepaths = [fp for fp in scenario_filepaths if fp.stem == cfg.scenario_id]
+        if not scenario_filepaths:
+            logger.error("No scenario found with ID '%s' under %s", cfg.scenario_id, scenario_base_path)
+            return
+        logger.info("Filtering to single scenario: %s", cfg.scenario_id)
+
     logger.info("Instatiating visualizer: %s", cfg.viz._target_)
     viz_config = copy.deepcopy(cfg.viz)
-    if cfg.viz_scored_scenarios:
+    if viz_scored_scenarios:
         valid_scenario_ids = [file.name for file in scores_path.glob("*.pkl")]
         scenario_filepaths = [fp for fp in scenario_filepaths if Path(fp).name in valid_scenario_ids]
 
-        base_meta_path = Path(cfg.meta_path)
-        match cfg.score_to_visualize:
-            case "individual":
-                viz_config.config.categories_file = base_meta_path / "gt_critical_categorical_individual.json"
-            case "interaction":
-                viz_config.config.categories_file = base_meta_path / "gt_critical_categorical_interaction.json"
-            case "safeshift":
-                viz_config.config.categories_file = base_meta_path / "gt_critical_categorical_safeshift.json"
-            case _:
-                pass
+        if (cat_filename := _CATEGORIES_FILENAME.get(cfg.score_to_visualize)) is not None:
+            viz_config.config.categories_file = Path(cfg.meta_path) / cat_filename
+
+    if viz_probed_scenarios:
+        probed_filepaths = _get_probed_filepaths(cfg)
+        if probed_filepaths is None:
+            return
+        scenario_filepaths = probed_filepaths
 
     visualizer: BaseVisualizer = hydra.utils.instantiate(viz_config)
     scenario_output_dirs = (
@@ -144,21 +212,16 @@ def run(cfg: DictConfig) -> None:
 
         logger.info("Visualizing scenario %s", scenario_filepath)
         scenario_data = from_pickle(str(scenario_filepath))  # nosec B301
-        scenario = dataset.transform_scenario_data(scenario_data)
+        if viz_probed_scenarios:
+            assert isinstance(scenario_data, Scenario), f"Expected Scenario, got {type(scenario_data)}"
+            scenario = scenario_data
+        else:
+            scenario = dataset.transform_scenario_data(scenario_data)
 
-        if cfg.viz_scored_scenarios:
+        if viz_scored_scenarios:
             score_filepath = scores_path / scenario_filepath.name
-            scenario_scores = from_pickle(str(score_filepath))  # nosec B301
-            scenario_scores = ScenarioScores.model_validate(scenario_scores)
-            match cfg.score_to_visualize:
-                case "individual":
-                    scores = scenario_scores.individual_scores
-                case "interaction":
-                    scores = scenario_scores.interaction_scores
-                case "safeshift":
-                    scores = scenario_scores.safeshift_scores
-                case _:
-                    scores = None
+            scenario_scores = ScenarioScores.model_validate(from_pickle(str(score_filepath)))  # nosec B301
+            scores = _select_scores(scenario_scores, cfg.score_to_visualize)
 
         _ = visualizer.visualize_scenario(scenario, scores=scores, output_dir=output_dir)
 

--- a/src/characterization/utils/viz/scenario.py
+++ b/src/characterization/utils/viz/scenario.py
@@ -41,7 +41,10 @@ class ScenarioVisualizer(BaseVisualizer):
         scenario_id = scenario.metadata.scenario_id
         suffix = (
             ""
-            if SupportedPanes.HIGHLIGHT_RELEVANT_AGENTS not in self.panes_to_plot
+            if (
+                SupportedPanes.HIGHLIGHT_RELEVANT_AGENTS not in self.panes_to_plot
+                and SupportedPanes.CATEGORICAL_AGENTS not in self.panes_to_plot
+            )
             or scores is None
             or scores.scene_score is None
             else f"_{round(scores.scene_score, 2)}"
@@ -60,28 +63,24 @@ class ScenarioVisualizer(BaseVisualizer):
                         axs[i] if self.num_panes_to_plot > 1 else axs, scenario, scores, title="All Agents"
                     )
                 case SupportedPanes.HIGHLIGHT_RELEVANT_AGENTS:
-                    if self.plot_categorical:
-                        # Plot sequence data with categorical agent scores. By default it uses autumn_r colormap, which
-                        # will show lower scored agents in yellow and higher scored agents in dark red.
-                        self.plot_sequences_categorical(
-                            axs[i] if self.num_panes_to_plot > 1 else axs,
-                            scenario,
-                            scores,
-                            title="Scenario with Agent Categorical Scores",
-                        )
-                    else:
-                        # Plot trajectory data with relevant agents in a different color
-                        self.plot_sequences(
-                            axs[i] if self.num_panes_to_plot > 1 else axs,
-                            scenario,
-                            scores,
-                            show_relevant=True,
-                            title="Relevant Agents Highlighted",
-                        )
+                    self.plot_sequences(
+                        axs[i] if self.num_panes_to_plot > 1 else axs,
+                        scenario,
+                        scores,
+                        show_relevant=True,
+                        title="Relevant Agents Highlighted",
+                    )
                 case SupportedPanes.COUNTERFACTUAL_PROBE:
                     self.plot_sequences_with_probe(
                         axs[i] if self.num_panes_to_plot > 1 else axs,
                         scenario,
+                    )
+                case SupportedPanes.CATEGORICAL_AGENTS:
+                    self.plot_sequences_categorical(
+                        axs[i] if self.num_panes_to_plot > 1 else axs,
+                        scenario,
+                        scores,
+                        title="Agent Categorical Scores",
                     )
 
         # Prepare and save plot

--- a/src/characterization/utils/viz/visualizer.py
+++ b/src/characterization/utils/viz/visualizer.py
@@ -40,6 +40,7 @@ class SupportedPanes(Enum):
     ALL_AGENTS = 0
     HIGHLIGHT_RELEVANT_AGENTS = 1
     COUNTERFACTUAL_PROBE = 2
+    CATEGORICAL_AGENTS = 3
 
 
 class BaseVisualizer(ABC):
@@ -107,8 +108,15 @@ class BaseVisualizer(ABC):
             AgentType.TYPE_RELEVANT: "coral",
         }
 
-        # Initialize the color map for risk-based categorical visualization
-        self.plot_categorical = config.get("plot_categorical", False)
+        # Set up panes to plot. It will fail if an invalid pane is provided.
+        panes = config.get("panes_to_plot", ["ALL_AGENTS"])
+        self.panes_to_plot = [SupportedPanes[pane] for pane in panes]
+        self.num_panes_to_plot = len(self.panes_to_plot)
+
+        # Initialize the color map for risk-based categorical visualization.
+        # Categorical mode is activated by including CATEGORICAL_AGENTS in panes_to_plot; it only
+        # affects the CATEGORICAL_AGENTS pane and does not alter any other pane's rendering.
+        self.plot_categorical = SupportedPanes.CATEGORICAL_AGENTS in self.panes_to_plot
         if self.plot_categorical:
             categories_filepath = Path(config.categories_file)
             if not categories_filepath.is_file():
@@ -124,13 +132,8 @@ class BaseVisualizer(ABC):
             colors = [color_map(v) for v in vals]  # RGBA
             # Convert RGBA to hex colors for matplotlib
             hex_colors = [f"#{int(r * 255):02x}{int(g * 255):02x}{int(b * 255):02x}" for r, g, b, _ in colors]
-            self.categorical_color_map = {i: hex_colors[i] for i in range(self.num_categories + 1)}
+            self.categorical_color_map = {i + 1: hex_colors[i] for i in range(self.num_categories)}
             self.categorical_color_map[-1] = "lightgray"  # Color for invalid scores
-
-        # Set up panes to plot. It will fail if an invalid pane is provided.
-        panes = config.get("panes_to_plot", ["ALL_AGENTS"])
-        self.panes_to_plot = [SupportedPanes[pane] for pane in panes]
-        self.num_panes_to_plot = len(self.panes_to_plot)
 
         # Number of workers for processing animations in parallel
         self.num_workers = config.get("num_workers", 10)
@@ -213,8 +216,8 @@ class BaseVisualizer(ABC):
 
         # Get the agent normalized scores
         if scores is None or scores.agent_scores is None:
-            error_message = "Scores with agent_scores are required for categorical visualization."
-            raise ValueError(error_message)
+            logger.warning("plot_sequences_categorical called without agent scores; skipping categorical pane.")
+            return
 
         agent_scores = scores.agent_scores
         agent_scores = BaseVisualizer.convert_to_risk_levels(agent_scores, self.categories_values)


### PR DESCRIPTION
This pull request refactors and extends the scenario visualization configuration and logic to support a more flexible, pane-driven approach for selecting which scenario data to load and which visualizations to render. It introduces a new `CATEGORICAL_AGENTS` pane, unifies configuration across scenarios, and streamlines how data is loaded and visualized based on the selected panes. The changes also improve error handling and code clarity.

Key changes include:

**Pane-driven Visualization and Data Loading:**

* Introduced `panes_to_plot` in viz config files (e.g., `all_panes_scenario.yaml`, `categorical_scenario.yaml`, `probe_scenario.yaml`) to explicitly control which panes are rendered for each scenario, replacing ad-hoc or boolean-based config options. [[1]](diffhunk://#diff-290d557b9db2ddaa730c9e9dd9be9dad7d6f926c93363b606671d4749afde9a1R1-R9) [[2]](diffhunk://#diff-dbae13c286aa8c256e4e00978aaa7cb4ff8aaafae747104cdb373ace72f89bb0L6-R7) [[3]](diffhunk://#diff-82a0d2f9af445cf40e9ad8c55bc358a27b9e8f00fbd2cb7f6ce904a57aa61674R1-R3)
* Added the `CATEGORICAL_AGENTS` pane to the `SupportedPanes` enum and updated the visualizer to support rendering categorical agent scores as a dedicated pane. [[1]](diffhunk://#diff-85a020a7af4300c3387fc34123b78f728b173a0776d584efed6af04b71bc2b7bR43) [[2]](diffhunk://#diff-0b61bf0813b3299740b6b9eaa6f1a6a5cef6a39a9736a21e2339d962461358f6R78-R84)
* Refactored the entrypoint (`run_scenario_viz.py`) to derive data loading logic (e.g., whether to load probed scenarios or scored scenarios) directly from the active `panes_to_plot` configuration, and updated the documentation and example usage accordingly. [[1]](diffhunk://#diff-df9a6fd7f7f6a0eb59bbe845a77be4bebd7c2d5c0cc118247d835d612e2438a5L3-R21) [[2]](diffhunk://#diff-df9a6fd7f7f6a0eb59bbe845a77be4bebd7c2d5c0cc118247d835d612e2438a5R162-R166)

**Refactoring and Simplification:**

* Removed the `plot_categorical` flag in favor of pane-driven logic, ensuring that categorical plotting is only activated by including the `CATEGORICAL_AGENTS` pane.
* Refactored how categorical color maps are constructed and fixed an off-by-one error in category mapping.

**Improved Error Handling and Robustness:**

* Improved error handling when required data (such as agent scores) is missing for categorical visualizations, logging a warning and skipping the pane instead of raising an exception.
* Enhanced error messages and filtering logic when loading scenarios by ID or from specific directories, and added helper functions for loading probed scenarios. [[1]](diffhunk://#diff-df9a6fd7f7f6a0eb59bbe845a77be4bebd7c2d5c0cc118247d835d612e2438a5R126-R145) [[2]](diffhunk://#diff-df9a6fd7f7f6a0eb59bbe845a77be4bebd7c2d5c0cc118247d835d612e2438a5R176-R196)

**Configuration and Behavior Changes:**

* Changed default behavior for showing the criticality gap and gap distance in `probe_scenario.yaml` to `false`.
* Updated internal helper functions for selecting scores and category files, improving maintainability and clarity. [[1]](diffhunk://#diff-df9a6fd7f7f6a0eb59bbe845a77be4bebd7c2d5c0cc118247d835d612e2438a5L24-R67) [[2]](diffhunk://#diff-df9a6fd7f7f6a0eb59bbe845a77be4bebd7c2d5c0cc118247d835d612e2438a5R215-R224)