### PR TITLE
perf(scoring): use compact ego-distance weights

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scenario-characterization"
-version = "0.4.3"
+version = "0.4.4"
 authors = [
     {name="Ingrid Navarro", email="ingridn@cmu.edu"},
     {name="Duan Yutong (dyt-stackav)"},

--- a/src/characterization/features/safeshift_features.py
+++ b/src/characterization/features/safeshift_features.py
@@ -6,7 +6,10 @@ from characterization.features.interaction_features import InteractionFeatures
 from characterization.schemas.scenario import Scenario
 from characterization.schemas.scenario_features import ScenarioFeatures
 from characterization.utils.common import AgentTrajectoryMasker
-from characterization.utils.geometric_utils import compute_agent_to_agent_closest_dists
+from characterization.utils.geometric_utils import (
+    compute_agent_to_agent_closest_dists,
+    compute_agent_to_ego_closest_dists,
+)
 from characterization.utils.io_utils import get_logger
 
 logger = get_logger(__name__)
@@ -84,6 +87,16 @@ class SafeShiftFeatures(BaseFeature):
         agent_trajectories = AgentTrajectoryMasker(agent_data.agent_trajectories)
         agent_positions = agent_trajectories.agent_xyz_pos
         pair_scope = "ego" if self.config.get("score_weighting_method", "uniform") == "distance_to_ego_agent" else "all"
+        agent_to_agent_closest_dists = None
+        agent_to_ego_closest_dists = None
+        if pair_scope == "ego":
+            agent_to_ego_closest_dists = compute_agent_to_ego_closest_dists(
+                agent_positions,
+                scenario.metadata.ego_vehicle_index,
+            )
+        else:
+            agent_to_agent_closest_dists = compute_agent_to_agent_closest_dists(agent_positions)
+
         return ScenarioFeatures(
             metadata=scenario.metadata,
             individual_features=self.individual_features.compute_individual_features(scenario),
@@ -92,5 +105,6 @@ class SafeShiftFeatures(BaseFeature):
                 max_workers=max_workers,
                 pair_scope=pair_scope,
             ),
-            agent_to_agent_closest_dists=compute_agent_to_agent_closest_dists(agent_positions),
+            agent_to_agent_closest_dists=agent_to_agent_closest_dists,
+            agent_to_ego_closest_dists=agent_to_ego_closest_dists,
         )

--- a/src/characterization/schemas/scenario_features.py
+++ b/src/characterization/schemas/scenario_features.py
@@ -106,6 +106,8 @@ class ScenarioFeatures(BaseModel):
         metadata (ScenarioMetadata): Metadata for the scenario, including IDs, timestamps, and thresholds.
         individual_features (IndividualFeatures | None): Individual features for each agent in the scenario.
         interaction_features (InteractionFeatures | None): Interaction features between agents in the scenario.
+        agent_to_ego_closest_dists (Float32NDArray1D | None): Minimum distance from each agent to the ego agent over
+            time.
     """
 
     metadata: ScenarioMetadata
@@ -117,4 +119,5 @@ class ScenarioFeatures(BaseModel):
     interaction_features: Interaction | None = None
 
     agent_to_agent_closest_dists: Float32NDArray2D | None = None
+    agent_to_ego_closest_dists: Float32NDArray1D | None = None
     model_config = {"arbitrary_types_allowed": True, "validate_assignment": True}

--- a/src/characterization/scorer/base_scorer.py
+++ b/src/characterization/scorer/base_scorer.py
@@ -124,14 +124,20 @@ class BaseScorer(ABC):
         Returns:
             NDArray[np.float32]: The computed weights for each agent.
         """
-        agent_to_agent_dists = BaseScorer._get_agent_to_agent_closest_dists(
-            scenario, scenario_features
-        )  # Shape (num_agents, num_agents)
-
         ego_agent_index = scenario.metadata.ego_vehicle_index
 
-        # Get distance between each agent and the ego agent
-        min_dist = agent_to_agent_dists[:, ego_agent_index] + EPSILON  # Shape (num_agents, 1)
+        # SafeShift features may provide only the distances needed by this weighting method. Fall back to the full
+        # matrix for older feature caches and callers that construct ScenarioFeatures directly.
+        agent_to_ego_dists = scenario_features.agent_to_ego_closest_dists
+        if agent_to_ego_dists is None:
+            agent_to_agent_dists = BaseScorer._get_agent_to_agent_closest_dists(
+                scenario, scenario_features
+            )  # Shape (num_agents, num_agents)
+            min_dist = agent_to_agent_dists[:, ego_agent_index]
+        else:
+            min_dist = np.nan_to_num(agent_to_ego_dists, nan=np.inf)
+
+        min_dist = min_dist + EPSILON  # Shape (num_agents,)
         if reduce_distance_penalty:
             min_dist = np.sqrt(min_dist)
 

--- a/src/characterization/utils/geometric_utils.py
+++ b/src/characterization/utils/geometric_utils.py
@@ -117,6 +117,33 @@ def compute_agent_to_agent_closest_dists(
     return closest_dists
 
 
+def compute_agent_to_ego_closest_dists(
+    positions: NDArray[np.float32],
+    ego_agent_index: int,
+) -> NDArray[np.float32]:
+    """Compute each agent's closest distance to the ego agent over its trajectory.
+
+    Args:
+        positions: Array of agent positions over time with shape [num_agents, num_time_steps, 3].
+        ego_agent_index: Index of the ego agent in ``positions``.
+
+    Returns:
+        Minimum distance from each agent to the ego agent over time with shape [num_agents]. NaN values are replaced
+            with infinity.
+
+    Raises:
+        ValueError: If ``ego_agent_index`` is invalid for the supplied positions.
+    """
+    num_agents = positions.shape[0]
+    if not 0 <= ego_agent_index < num_agents:
+        error_message = f"ego_agent_index={ego_agent_index} is invalid for a scenario with {num_agents} agents."
+        raise ValueError(error_message)
+
+    ego_positions = positions[ego_agent_index]
+    dists = np.linalg.norm(positions - ego_positions[np.newaxis, :], axis=-1)
+    return np.nan_to_num(np.nanmin(dists, axis=-1), nan=np.inf).astype(np.float32)
+
+
 def find_conflict_points(  # noqa: PLR0912
     scenario: Scenario,
     ndim: int = 3,

--- a/tests/test_ego_distance_weighting.py
+++ b/tests/test_ego_distance_weighting.py
@@ -1,0 +1,106 @@
+"""Tests for compact ego-distance weighting."""
+
+import unittest
+
+import numpy as np
+from omegaconf import DictConfig
+
+from characterization.schemas.scenario import AgentData, Scenario, ScenarioMetadata
+from characterization.schemas.scenario_features import Interaction, ScenarioFeatures
+from characterization.scorer.interaction_scorer import InteractionScorer
+from characterization.utils.common import InteractionStatus
+from characterization.utils.geometric_utils import (
+    compute_agent_to_agent_closest_dists,
+    compute_agent_to_ego_closest_dists,
+)
+from characterization.utils.scenario_types import AgentType
+
+
+class EgoDistanceWeightingTest(unittest.TestCase):
+    """Tests that compact ego distances preserve scoring weights."""
+
+    def test_compact_distances_preserve_ego_weights(self) -> None:
+        """Full and compact distance features produce identical ego weights."""
+        positions = np.asarray(
+            [
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+                [[3.0, 0.0, 0.0], [3.0, 1.0, 0.0], [3.0, 2.0, 0.0]],
+                [[10.0, 0.0, 0.0], [10.0, 1.0, 0.0], [10.0, 2.0, 0.0]],
+            ],
+            dtype=np.float32,
+        )
+        trajectory = np.zeros((3, 3, 10), dtype=np.float32)
+        trajectory[:, :, :3] = positions
+        trajectory[:, :, 9] = 1.0
+        metadata = ScenarioMetadata(
+            scenario_id="ego-weight-test",
+            timestamps_seconds=[0.0, 1.0, 2.0],
+            frequency_hz=1.0,
+            current_time_index=0,
+            ego_vehicle_id=1,
+            ego_vehicle_index=1,
+            objects_of_interest=[],
+            track_length=3,
+            dataset="test",
+        )
+        scenario = Scenario(
+            metadata=metadata,
+            agent_data=AgentData(
+                agent_ids=[0, 1, 2],
+                agent_types=[AgentType.TYPE_VEHICLE] * 3,
+                agent_trajectories=trajectory,
+            ),
+        )
+        full_features = ScenarioFeatures(
+            metadata=metadata,
+            agent_to_agent_closest_dists=compute_agent_to_agent_closest_dists(positions, chunk_size=1),
+        )
+        compact_features = ScenarioFeatures(
+            metadata=metadata,
+            agent_to_ego_closest_dists=compute_agent_to_ego_closest_dists(positions, ego_agent_index=1),
+        )
+
+        scorer = InteractionScorer(
+            DictConfig(
+                {
+                    "interaction_score_function": "simple",
+                    "score_weighting_method": "distance_to_ego_agent",
+                    "score_clip": {"min": 0.0, "max": 200.0},
+                }
+            )
+        )
+        full_weights = scorer.get_weights(scenario, full_features)
+        compact_weights = scorer.get_weights(scenario, compact_features)
+
+        np.testing.assert_array_equal(compact_weights, full_weights)
+
+        interaction = Interaction(
+            collision=np.asarray([1.0, 0.0], dtype=np.float32),
+            inv_mttcp=np.asarray([1.0, 0.2], dtype=np.float32),
+            inv_thw=np.asarray([0.4, 0.1], dtype=np.float32),
+            inv_ttc=np.asarray([0.3, 0.05], dtype=np.float32),
+            drac=np.asarray([2.0, 0.5], dtype=np.float32),
+            interaction_status=[InteractionStatus.COMPUTED_OK, InteractionStatus.COMPUTED_OK],
+            interaction_agent_indices=[(0, 1), (1, 2)],
+        )
+        full_score = scorer.compute_interaction_score(
+            scenario,
+            ScenarioFeatures(
+                metadata=metadata,
+                interaction_features=interaction,
+                agent_to_agent_closest_dists=full_features.agent_to_agent_closest_dists,
+            ),
+        )
+        compact_score = scorer.compute_interaction_score(
+            scenario,
+            ScenarioFeatures(
+                metadata=metadata,
+                interaction_features=interaction,
+                agent_to_ego_closest_dists=compact_features.agent_to_ego_closest_dists,
+            ),
+        )
+
+        assert compact_score.agent_scores is not None
+        assert full_score.agent_scores is not None
+        np.testing.assert_array_equal(compact_score.agent_scores, full_score.agent_scores)
+        assert compact_score.scene_score == full_score.scene_score

--- a/tests/test_geometric_utils.py
+++ b/tests/test_geometric_utils.py
@@ -4,7 +4,10 @@ import unittest
 
 import numpy as np
 
-from characterization.utils.geometric_utils import compute_agent_to_agent_closest_dists
+from characterization.utils.geometric_utils import (
+    compute_agent_to_agent_closest_dists,
+    compute_agent_to_ego_closest_dists,
+)
 
 
 class ClosestDistanceTest(unittest.TestCase):
@@ -33,3 +36,18 @@ class ClosestDistanceTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):  # noqa: PT027
             compute_agent_to_agent_closest_dists(positions, chunk_size=0)
+
+    def test_ego_distances_match_full_matrix_column(self) -> None:
+        """Compact ego distances match the corresponding full-matrix values."""
+        positions = np.asarray(
+            [
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+                [[3.0, 0.0, 0.0], [3.0, 1.0, 0.0], [3.0, 2.0, 0.0]],
+                [[10.0, 0.0, 0.0], [10.0, 1.0, 0.0], [10.0, 2.0, 0.0]],
+            ],
+            dtype=np.float32,
+        )
+        full_distances = compute_agent_to_agent_closest_dists(positions, chunk_size=1)
+        ego_distances = compute_agent_to_ego_closest_dists(positions, ego_agent_index=1)
+
+        np.testing.assert_array_equal(ego_distances, full_distances[:, 1])


### PR DESCRIPTION
### motivation

The `distance_to_ego_agent` weighting method requires only each agent's minimum distance to the ego vehicle, but SafeShift currently computes and stores the complete agent-by-agent distance matrix. Storing the required one-dimensional feature reduces memory and computation while retaining compatibility with existing feature caches.

### changes

- Add `compute_agent_to_ego_closest_dists` and expose its one-dimensional result through `ScenarioFeatures.agent_to_ego_closest_dists`.
- Have `SafeShiftFeatures` compute the compact ego-distance vector for distance-based ego weighting and retain the full matrix for other weighting modes.
- Update `BaseScorer` to consume the compact vector and fall back to the full matrix when older caches or manually constructed features do not contain it.
- Add equivalence tests demonstrating that compact and full distance features produce identical agent weights and interaction scores, and bump the package version to `0.4.4`.

### validation

- `git diff --check 5181911^ 5181911` passed.
- `.venv/bin/python -m unittest discover -v` passed all 8 tests at the stack tip, including compact-distance and scoring-equivalence coverage.

### stack

This is PR 3 of 6 in a stack (newest at the top)
- #187
- #186
- #185
- #184 (This PR)
- #183
- #182
