### PR TITLE
perf(interaction): reuse pair separations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scenario-characterization"
-version = "0.4.4"
+version = "0.4.5"
 authors = [
     {name="Ingrid Navarro", email="ingridn@cmu.edu"},
     {name="Duan Yutong (dyt-stackav)"},

--- a/src/characterization/features/interaction_features.py
+++ b/src/characterization/features/interaction_features.py
@@ -404,9 +404,16 @@ def _process_agent_pair_worker(n: int, i: int, j: int) -> tuple[int, Interaction
         leading_agent = interaction.find_leading_agent(agent_i, agent_j, valid_headings)
 
         # Now compute leader-follower interaction state
-        thws = interaction.compute_thw(agent_i, agent_j, leading_agent, valid_headings)
-        ttcs = interaction.compute_ttc(agent_i, agent_j, leading_agent, valid_headings)
-        dracs = interaction.compute_drac(agent_i, agent_j, leading_agent, valid_headings, agent_max_deceleration)
+        thws = interaction.compute_thw(agent_i, agent_j, leading_agent, valid_headings, separations=separations)
+        ttcs = interaction.compute_ttc(agent_i, agent_j, leading_agent, valid_headings, separations=separations)
+        dracs = interaction.compute_drac(
+            agent_i,
+            agent_j,
+            leading_agent,
+            valid_headings,
+            agent_max_deceleration,
+            separations=separations,
+        )
         status = InteractionStatus.COMPUTED_OK
 
     match return_criterion:

--- a/src/characterization/features/interaction_utils.py
+++ b/src/characterization/features/interaction_utils.py
@@ -198,6 +198,8 @@ def compute_thw(
     agent_j: InteractionAgent,
     leading_agent: NDArray[np.intp],
     valid_headings: NDArray[np.intp] | None = None,
+    *,
+    separations: NDArray[np.float32] | None = None,
 ) -> NDArray[np.float32]:
     """Computes the following leader-follower interaction measurements.
 
@@ -212,6 +214,8 @@ def compute_thw(
         agent_j (InteractionAgent): The second agent.
         leading_agent (NDArray[np.intp]): Array indicating which agent is leading (0 for agent_i, 1 for agent_j).
         valid_headings (NDArray[np.intp] | None): Optional mask to filter valid headings.
+        separations (NDArray[np.float32] | None): Optional precomputed pairwise separation distances. If omitted,
+            separations are computed from the agent positions.
 
     Returns:
         thw (NDArray[np.float32]): Array of time headway values for each timestep (shape: [T,]).
@@ -226,6 +230,12 @@ def compute_thw(
         position_j = position_j[valid_headings]
         speed_j = speed_j[valid_headings]
         length_j = length_j[valid_headings]
+    if separations is None:
+        separation_values = np.linalg.norm(position_i - position_j, axis=-1)
+    elif valid_headings is None:
+        separation_values = separations
+    else:
+        separation_values = separations[valid_headings]
 
     thw = np.full(position_i.shape[0], np.inf, dtype=np.float32)
 
@@ -233,13 +243,13 @@ def compute_thw(
     # ...where i is the agent ahead
     i_idx = np.where(leading_agent == 0)[0]
     if len(i_idx) > 0:
-        d_i = np.linalg.norm(position_i[i_idx] - position_j[i_idx], axis=-1) - length_i[i_idx]
+        d_i = separation_values[i_idx] - length_i[i_idx]
         thw[i_idx] = d_i / (speed_j[i_idx] + EPSILON)
 
     # ...where j is the agent ahead
     j_idx = np.where(leading_agent == 1)[0]
     if len(j_idx) > 0:
-        d_j = np.linalg.norm(position_j[j_idx] - position_i[j_idx], axis=-1) - length_j[j_idx]
+        d_j = separation_values[j_idx] - length_j[j_idx]
         thw[j_idx] = d_j / (speed_i[j_idx] + EPSILON)
 
     return np.abs(thw)
@@ -250,6 +260,8 @@ def compute_ttc(
     agent_j: InteractionAgent,
     leading_agent: NDArray[np.intp],
     valid_headings: NDArray[np.intp] | None = None,
+    *,
+    separations: NDArray[np.float32] | None = None,
 ) -> NDArray[np.float32]:
     """Computes the following leader-follower interaction measurement.
 
@@ -267,6 +279,8 @@ def compute_ttc(
         agent_j (InteractionAgent): The second agent.
         leading_agent (NDArray[np.intp]): Array indicating which agent is leading (0 for agent_i, 1 for agent_j).
         valid_headings (NDArray[np.intp] | None): Optional mask to filter valid headings.
+        separations (NDArray[np.float32] | None): Optional precomputed pairwise separation distances. If omitted,
+            separations are computed from the agent positions.
 
     Returns:
         ttc (NDArray[np.float32]): Array of time-to-collision values for each timestep (shape: [T,]).
@@ -281,6 +295,12 @@ def compute_ttc(
         position_j = position_j[valid_headings]
         speed_j = speed_j[valid_headings]
         length_j = length_j[valid_headings]
+    if separations is None:
+        separation_values = np.linalg.norm(position_i - position_j, axis=-1)
+    elif valid_headings is None:
+        separation_values = separations
+    else:
+        separation_values = separations[valid_headings]
 
     ttc = np.full(position_i.shape[0], np.inf, dtype=np.float32)
 
@@ -289,7 +309,7 @@ def compute_ttc(
     j_faster = np.where(speed_j > speed_i)[0]
     i_idx = np.intersect1d(i_leads, j_faster)
     if len(i_idx) > 0:
-        d_ij = np.linalg.norm(position_i[i_idx] - position_j[i_idx], axis=-1) - length_i[i_idx]
+        d_ij = separation_values[i_idx] - length_i[i_idx]
         ttc[i_idx] = d_ij / (speed_j[i_idx] - speed_i[i_idx] + EPSILON)
 
     # ...where j is the agent ahead and i's speed is higher
@@ -297,7 +317,7 @@ def compute_ttc(
     i_faster = np.where(speed_i > speed_j)[0]
     j_idx = np.intersect1d(j_leads, i_faster)
     if len(j_idx) > 0:
-        d_ji = np.linalg.norm(position_j[j_idx] - position_i[j_idx], axis=-1) - length_j[j_idx]
+        d_ji = separation_values[j_idx] - length_j[j_idx]
         ttc[j_idx] = d_ji / (speed_i[j_idx] - speed_j[j_idx] + EPSILON)
 
     return np.abs(ttc)
@@ -309,6 +329,8 @@ def compute_drac(
     leading_agent: NDArray[np.intp],
     valid_headings: NDArray[np.intp] | None = None,
     max_deceleration: float = MAX_DECELERATION,
+    *,
+    separations: NDArray[np.float32] | None = None,
 ) -> NDArray[np.float32]:
     """Computes the following leader-follower interaction measurement.
 
@@ -326,6 +348,8 @@ def compute_drac(
         leading_agent (NDArray[np.intp]): Array indicating which agent is leading (0 for agent_i, 1 for agent_j).
         valid_headings (NDArray[np.intp] | None): Optional mask to filter valid headings.
         max_deceleration (float): Maximum deceleration value to clip DRAC values.
+        separations (NDArray[np.float32] | None): Optional precomputed pairwise separation distances. If omitted,
+            separations are computed from the agent positions.
 
     Returns:
         drac (NDArray[np.float32]): Array of time-to-collision values for each timestep (shape: [T,]).
@@ -340,6 +364,12 @@ def compute_drac(
         position_j = position_j[valid_headings]
         speed_j = speed_j[valid_headings]
         length_j = length_j[valid_headings]
+    if separations is None:
+        separation_values = np.linalg.norm(position_i - position_j, axis=-1)
+    elif valid_headings is None:
+        separation_values = separations
+    else:
+        separation_values = separations[valid_headings]
 
     drac = np.full(position_i.shape[0], 0.0, dtype=np.float32)
 
@@ -348,7 +378,7 @@ def compute_drac(
     j_faster = np.where(speed_j > speed_i)[0]
     i_idx = np.intersect1d(i_leads, j_faster)
     if len(i_idx) > 0:
-        d_ij = np.linalg.norm(position_i[i_idx] - position_j[i_idx], axis=-1) - length_i[i_idx]
+        d_ij = separation_values[i_idx] - length_i[i_idx]
         v_ji = speed_j[i_idx] - speed_i[i_idx]
         drac[i_idx] = (v_ji**2) / (2 * np.abs(d_ij) + EPSILON)
 
@@ -357,7 +387,7 @@ def compute_drac(
     i_faster = np.where(speed_i > speed_j)[0]
     j_idx = np.intersect1d(j_leads, i_faster)
     if len(j_idx) > 0:
-        d_ji = np.linalg.norm(position_j[j_idx] - position_i[j_idx], axis=-1) - length_j[j_idx]
+        d_ji = separation_values[j_idx] - length_j[j_idx]
         v_ij = speed_i[j_idx] - speed_j[j_idx]
         drac[j_idx] = (v_ij**2) / (2 * np.abs(d_ji) + EPSILON)
 

--- a/tests/test_interaction_utils.py
+++ b/tests/test_interaction_utils.py
@@ -1,0 +1,53 @@
+import unittest
+
+import numpy as np
+
+from characterization.features.interaction_utils import (
+    compute_drac,
+    compute_separation,
+    compute_thw,
+    compute_ttc,
+)
+from characterization.utils.common import InteractionAgent
+
+
+class SeparationReuseTest(unittest.TestCase):
+    """Test reuse of precomputed pair separation distances."""
+
+    def test_metric_helpers_match_without_precomputed_separations(self) -> None:
+        """Ensure precomputed separations preserve all metric-helper outputs."""
+        agent_i = InteractionAgent()
+        agent_j = InteractionAgent()
+        agent_i.position = np.asarray(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]],
+            dtype=np.float32,
+        )
+        agent_j.position = np.asarray(
+            [[2.0, 0.0, 0.0], [1.5, 0.0, 0.0], [2.5, 0.0, 0.0], [4.0, 0.0, 0.0]],
+            dtype=np.float32,
+        )
+        agent_i.speed = np.asarray([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+        agent_j.speed = np.asarray([2.0, 1.0, 2.0, 1.0], dtype=np.float32)
+        agent_i.length = np.full(4, 1.0, dtype=np.float32)
+        agent_j.length = np.full(4, 1.0, dtype=np.float32)
+
+        valid_headings = np.asarray([0, 1, 3], dtype=np.intp)
+        leading_agent = np.asarray([0, 1, 0], dtype=np.intp)
+        separations = compute_separation(agent_i, agent_j)
+
+        np.testing.assert_array_equal(
+            compute_thw(agent_i, agent_j, leading_agent, valid_headings),
+            compute_thw(agent_i, agent_j, leading_agent, valid_headings, separations=separations),
+        )
+        np.testing.assert_array_equal(
+            compute_ttc(agent_i, agent_j, leading_agent, valid_headings),
+            compute_ttc(agent_i, agent_j, leading_agent, valid_headings, separations=separations),
+        )
+        np.testing.assert_array_equal(
+            compute_drac(agent_i, agent_j, leading_agent, valid_headings),
+            compute_drac(agent_i, agent_j, leading_agent, valid_headings, separations=separations),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### motivation

The pairwise interaction worker computes the same per-timestep agent separation independently for time headway, time to collision, and deceleration-rate metrics. Reusing the already available separation array removes repeated norm calculations from the worker's hot path without changing the public behaviour of direct metric-helper callers.

### changes

- Add an optional keyword-only `separations` argument to `compute_thw`, `compute_ttc`, and `compute_drac`.
- Preserve the existing computation as the fallback when precomputed separations are not supplied, including correct indexing for filtered headings.
- Pass the pair separation calculated by the interaction worker into all three metric helpers.
- Add regression coverage proving that reused separations produce identical outputs to on-demand computation, and bump the package version to `0.4.5`.

### validation

- `git diff --check ead17e0^ ead17e0` passed.
- `.venv/bin/python -m unittest discover -v` passed all 8 tests at the stack tip, including separation-reuse equivalence coverage.

### stack

This is PR 4 of 6 in a stack (newest at the top)
- #187
- #186
- #185 (This PR)
- #184
- #183
- #182
