### PR TITLE
perf(interaction): cull disjoint intersection segments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scenario-characterization"
-version = "0.4.5"
+version = "0.4.6"
 authors = [
     {name="Ingrid Navarro", email="ingridn@cmu.edu"},
     {name="Duan Yutong (dyt-stackav)"},

--- a/src/characterization/features/interaction_utils.py
+++ b/src/characterization/features/interaction_utils.py
@@ -128,12 +128,32 @@ def compute_intersections(agent_i: InteractionAgent, agent_j: InteractionAgent) 
 
     segments_i = np.stack([position_i[:-1], position_i[1:]], axis=1)
     segments_j = np.stack([position_j[:-1], position_j[1:]], axis=1)
-    segments_i = [LineString(x) for x in segments_i]
-    segments_j = [LineString(x) for x in segments_j]
 
-    intersections = [x.intersects(y) for x, y in zip(segments_i, segments_j, strict=False)]
+    # Segment bounding boxes provide an exact rejection test before constructing Shapely geometries. Shapely's
+    # predicates operate on the XY projection of these coordinates, so Z is intentionally excluded here.
+    segment_min_i = segments_i[:, :, :2].min(axis=1)
+    segment_max_i = segments_i[:, :, :2].max(axis=1)
+    segment_min_j = segments_j[:, :, :2].min(axis=1)
+    segment_max_j = segments_j[:, :, :2].max(axis=1)
+    boxes_overlap = np.logical_and(
+        np.all(segment_min_i <= segment_max_j, axis=1),
+        np.all(segment_min_j <= segment_max_i, axis=1),
+    )
+
+    # Preserve the previous Shapely behaviour for non-finite coordinates rather than rejecting them via NaN bounds.
+    finite_segments = np.logical_and(
+        np.isfinite(segments_i[:, :, :2]).all(axis=(1, 2)),
+        np.isfinite(segments_j[:, :, :2]).all(axis=(1, 2)),
+    )
+    candidate_segments = np.flatnonzero(boxes_overlap | ~finite_segments)
+    intersections = np.zeros(segments_i.shape[0], dtype=bool)
+    for segment_index in candidate_segments:
+        intersections[segment_index] = LineString(segments_i[segment_index]).intersects(
+            LineString(segments_j[segment_index])
+        )
+
     # Make it consistent with the number of timesteps
-    return np.array([intersections[0]] + intersections, dtype=bool)  # noqa: RUF005
+    return np.concatenate(([intersections[0]], intersections))
 
 
 def compute_mttcp(

--- a/tests/test_intersection_culling.py
+++ b/tests/test_intersection_culling.py
@@ -1,0 +1,54 @@
+import unittest
+
+import numpy as np
+from numpy.typing import NDArray
+from shapely import LineString
+
+from characterization.features.interaction_utils import compute_intersections
+from characterization.utils.common import InteractionAgent
+
+
+def _reference_intersections(positions_i: NDArray[np.float32], positions_j: NDArray[np.float32]) -> NDArray[np.bool_]:
+    segments_i = np.stack([positions_i[:-1], positions_i[1:]], axis=1)
+    segments_j = np.stack([positions_j[:-1], positions_j[1:]], axis=1)
+    intersections = [
+        LineString(segment_i).intersects(LineString(segment_j))
+        for segment_i, segment_j in zip(segments_i, segments_j, strict=False)
+    ]
+    return np.asarray([intersections[0], *intersections], dtype=bool)
+
+
+class IntersectionCullingTest(unittest.TestCase):
+    """Test that AABB rejection preserves Shapely intersection results."""
+
+    def test_intersections_match_reference_geometry(self) -> None:
+        """Ensure culling does not change crossing, touching, or disjoint segment results."""
+        cases = (
+            (
+                np.asarray([[0.0, 0.0, 0.0], [2.0, 2.0, 0.0], [4.0, 0.0, 0.0]], dtype=np.float32),
+                np.asarray([[0.0, 2.0, 0.0], [2.0, 0.0, 0.0], [4.0, 2.0, 0.0]], dtype=np.float32),
+            ),
+            (
+                np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]], dtype=np.float32),
+                np.asarray([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]], dtype=np.float32),
+            ),
+            (
+                np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]], dtype=np.float32),
+                np.asarray([[0.0, 2.0, 0.0], [1.0, 2.0, 0.0], [2.0, 2.0, 0.0]], dtype=np.float32),
+            ),
+        )
+
+        for positions_i, positions_j in cases:
+            agent_i = InteractionAgent()
+            agent_j = InteractionAgent()
+            agent_i.position = positions_i
+            agent_j.position = positions_j
+
+            np.testing.assert_array_equal(
+                compute_intersections(agent_i, agent_j),
+                _reference_intersections(positions_i, positions_j),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### motivation

Intersection detection constructs Shapely geometries for every pair of trajectory segments, although axis-aligned bounding boxes can reject disjoint segment pairs exactly in the XY plane. Performing this inexpensive rejection first reduces geometry construction and predicate overhead while preserving the established intersection results.

### changes

- Add an XY-axis-aligned bounding-box overlap test before constructing Shapely `LineString` objects.
- Preserve the previous Shapely path for overlapping candidates and for segments with non-finite coordinates, avoiding behavioural changes caused by NaN bounds.
- Retain the existing timestep alignment and boolean output ordering.
- Add regression tests for crossing, touching, and disjoint segments, and bump the package version to `0.4.6`.

### validation

- `git diff --check a4fa474^ a4fa474` passed.
- `.venv/bin/python -m unittest discover -v` passed all 8 tests at the stack tip, including comparison with the unculled Shapely reference implementation.

### stack

This is PR 5 of 6 in a stack (newest at the top)
- #187
- #186 (This PR)
- #185
- #184
- #183
- #182
