### PR TITLE
perf(interaction): chunk mttcp distance search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scenario-characterization"
-version = "0.4.6"
+version = "0.4.7"
 authors = [
     {name="Ingrid Navarro", email="ingridn@cmu.edu"},
     {name="Duan Yutong (dyt-stackav)"},

--- a/src/characterization/features/interaction_utils.py
+++ b/src/characterization/features/interaction_utils.py
@@ -160,6 +160,8 @@ def compute_mttcp(
     agent_i: InteractionAgent,
     agent_j: InteractionAgent,
     agent_to_agent_max_distance: float = 0.5,
+    *,
+    chunk_size: int = 256,
 ) -> NDArray[np.float32]:
     """Computes the minimum time to conflict point (mTTCP) between two agents.
 
@@ -174,41 +176,55 @@ def compute_mttcp(
         agent_i (InteractionAgent): The first agent.
         agent_j (InteractionAgent): The second agent.
         agent_to_agent_max_distance (float): The maximum distance between agents to consider for mTTCP.
+        chunk_size (int): Number of agent-i timesteps and conflict points to process per chunk. Smaller values reduce
+            peak memory usage. Defaults to 256.
 
     Returns:
         mttcp (NDArray[np.float32]): An array of mTTCP values for each timestep (shape: [N,]), or [np.inf] if no valid
             pairs are found.
     """
+    if chunk_size <= 0:
+        error_message = f"chunk_size must be positive; got {chunk_size}."
+        raise ValueError(error_message)
+
     position_i, position_j = agent_i.position, agent_j.position
     vel_i, vel_j = agent_i.speed, agent_j.speed
 
-    # T, 2 -> T, T
-    dists = np.linalg.norm(position_i[:, None, :] - position_j, axis=-1)
-    i_idx, _ = np.where(dists <= agent_to_agent_max_distance)
+    # The dense implementation formed a (T, T) distance matrix. Process rows in chunks while retaining the same
+    # per-row proximity predicate and ascending conflict-point order.
+    conflict_time_indices: list[NDArray[np.intp]] = []
+    for start in range(0, position_i.shape[0], chunk_size):
+        position_i_chunk = position_i[start : start + chunk_size]
+        dists = np.linalg.norm(position_i_chunk[:, None, :] - position_j, axis=-1)
+        close_timesteps = np.any(dists <= agent_to_agent_max_distance, axis=1)
+        conflict_time_indices.append(start + np.flatnonzero(close_timesteps))
 
-    _, i_unique = np.unique(i_idx, return_index=True)
-    ti = i_idx[i_unique]
-    if len(ti) == 0:
+    ti = np.concatenate(conflict_time_indices) if conflict_time_indices else np.empty(0, dtype=np.intp)
+    if ti.size == 0:
         return np.array([np.inf], dtype=np.float32)
 
     conflict_points = position_i[ti]
     mttcp = np.inf * np.ones(conflict_points.shape[0], dtype=np.float32)
 
-    cp_to_position_i = np.linalg.norm(position_i - conflict_points[:, None], axis=-1)
-    cp_to_position_j = np.linalg.norm(position_j - conflict_points[:, None], axis=-1)
-    tj = cp_to_position_j.argmin(axis=-1)
+    # Process conflict points in chunks as well, avoiding a second dense (num_conflict_points, T) allocation.
+    for start in range(0, conflict_points.shape[0], chunk_size):
+        end = start + chunk_size
+        conflict_points_chunk = conflict_points[start:end]
+        cp_to_position_i = np.linalg.norm(position_i - conflict_points_chunk[:, None], axis=-1)
+        cp_to_position_j = np.linalg.norm(position_j - conflict_points_chunk[:, None], axis=-1)
+        tj = cp_to_position_j.argmin(axis=-1)
 
-    t_min = np.minimum(ti, tj) + 1
-    for n, t in enumerate(t_min):
-        # Compute the time to conflict point for each agent
-        ttcp_i = cp_to_position_i[n, :t] / vel_i[:t]  # Shape: (num. conflict points, 0 to t)
-        ttcp_j = cp_to_position_j[n, :t] / vel_j[:t]
+        t_min = np.minimum(ti[start:end], tj) + 1
+        for n, t in enumerate(t_min):
+            # Compute the time to conflict point for each agent
+            ttcp_i = cp_to_position_i[n, :t] / vel_i[:t]  # Shape: (num. conflict points, 0 to t)
+            ttcp_j = cp_to_position_j[n, :t] / vel_j[:t]
 
-        # Calculate the absolute difference in time to conflict point
-        ttcp = np.abs(ttcp_i - ttcp_j)
+            # Calculate the absolute difference in time to conflict point
+            ttcp = np.abs(ttcp_i - ttcp_j)
 
-        # Update the minimum mTTCP
-        mttcp[n] = ttcp.min()
+            # Update the minimum mTTCP
+            mttcp[start + n] = ttcp.min()
 
     return mttcp
 

--- a/tests/test_interaction_utils.py
+++ b/tests/test_interaction_utils.py
@@ -1,14 +1,46 @@
 import unittest
 
 import numpy as np
+from numpy.typing import NDArray
 
 from characterization.features.interaction_utils import (
     compute_drac,
+    compute_mttcp,
     compute_separation,
     compute_thw,
     compute_ttc,
 )
 from characterization.utils.common import InteractionAgent
+
+
+def _dense_mttcp_reference(
+    agent_i: InteractionAgent,
+    agent_j: InteractionAgent,
+    agent_to_agent_max_distance: float,
+) -> NDArray[np.float32]:
+    position_i, position_j = agent_i.position, agent_j.position
+    vel_i, vel_j = agent_i.speed, agent_j.speed
+
+    dists = np.linalg.norm(position_i[:, None, :] - position_j, axis=-1)
+    i_idx, _ = np.where(dists <= agent_to_agent_max_distance)
+    _, i_unique = np.unique(i_idx, return_index=True)
+    ti = i_idx[i_unique]
+    if len(ti) == 0:
+        return np.array([np.inf], dtype=np.float32)
+
+    conflict_points = position_i[ti]
+    mttcp = np.inf * np.ones(conflict_points.shape[0], dtype=np.float32)
+    cp_to_position_i = np.linalg.norm(position_i - conflict_points[:, None], axis=-1)
+    cp_to_position_j = np.linalg.norm(position_j - conflict_points[:, None], axis=-1)
+    tj = cp_to_position_j.argmin(axis=-1)
+
+    t_min = np.minimum(ti, tj) + 1
+    for n, t in enumerate(t_min):
+        ttcp_i = cp_to_position_i[n, :t] / vel_i[:t]
+        ttcp_j = cp_to_position_j[n, :t] / vel_j[:t]
+        mttcp[n] = np.abs(ttcp_i - ttcp_j).min()
+
+    return mttcp
 
 
 class SeparationReuseTest(unittest.TestCase):
@@ -47,6 +79,39 @@ class SeparationReuseTest(unittest.TestCase):
             compute_drac(agent_i, agent_j, leading_agent, valid_headings),
             compute_drac(agent_i, agent_j, leading_agent, valid_headings, separations=separations),
         )
+
+    def test_mttcp_chunking_matches_dense_reference(self) -> None:
+        """Ensure chunked mTTCP processing preserves the dense implementation for several chunk sizes."""
+        agent_i = InteractionAgent()
+        agent_j = InteractionAgent()
+        agent_i.position = np.asarray(
+            [[float(index), 0.0, 0.0] for index in range(7)],
+            dtype=np.float32,
+        )
+        agent_j.position = np.asarray(
+            [[6.0 - float(index), 0.25, 0.0] for index in range(7)],
+            dtype=np.float32,
+        )
+        agent_i.speed = np.full(7, 2.0, dtype=np.float32)
+        agent_j.speed = np.full(7, 1.5, dtype=np.float32)
+        threshold = 0.5
+        expected = _dense_mttcp_reference(agent_i, agent_j, threshold)
+
+        for chunk_size in (1, 2, 256):
+            np.testing.assert_array_equal(
+                compute_mttcp(agent_i, agent_j, threshold, chunk_size=chunk_size),
+                expected,
+            )
+
+    def test_mttcp_rejects_non_positive_chunk_size(self) -> None:
+        """Ensure invalid mTTCP chunk sizes fail before allocating work buffers."""
+        raised = False
+        try:
+            compute_mttcp(InteractionAgent(), InteractionAgent(), chunk_size=0)
+        except ValueError:
+            raised = True
+
+        assert raised
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### motivation

The mTTCP implementation creates dense timestep-by-timestep distance arrays both while finding candidate conflict points and while evaluating distances from conflict points to trajectories. These allocations scale quadratically with trajectory length and can dominate memory use for long scenarios.

### changes

- Add a keyword-only `chunk_size` parameter to `compute_mttcp`, defaulting to 256, with explicit validation for positive values.
- Chunk the proximity search over agent-i timesteps and chunk conflict-point distance calculations while preserving candidate ordering and the existing no-candidate result.
- Add regression tests comparing multiple chunk sizes with a dense reference implementation and covering invalid chunk sizes.
- Bump the package version to `0.4.7`.

### validation

- `git diff --check 6bcefc2^ 6bcefc2` passed.
- `.venv/bin/python -m unittest discover -v` passed all 8 tests at the stack tip, including dense-reference equivalence and invalid-parameter coverage.

### stack

This is PR 6 of 6 in a stack (newest at the top)
- #187 (This PR)
- #186
- #185
- #184
- #183
- #182
