### PR TITLE
Add dataset analysis statistics

### DIFF
--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -68,6 +68,76 @@ Commonly overridden keys:
 | <img width="300" height="200" alt="individual_speed_limit_diff_type_vehicle_distributions" src="https://github.com/user-attachments/assets/be2f6bbf-3ae3-400d-840d-35ac43758605" /> <!-- pragma: allowlist secret -->  | <img width="300" height="200" alt="individual_speed_limit_diff_type_cyclist_distributions" src="https://github.com/user-attachments/assets/189d1c0c-7627-4d94-8a51-7f975264a3e1" /> <!-- pragma: allowlist secret -->  | <img width="300" height="200" alt="individual_speed_limit_diff_type_pedestrian_distributions" src="https://github.com/user-attachments/assets/5e7c58bc-5636-4dbc-a7df-d6d6e360d2e8" /> <!-- pragma: allowlist secret -->  |
 | | | |
 
+## Dataset Analysis
+
+The dataset analysis utility counts how many individual trajectories and interaction pairs each dataset
+contributes, broken down by agent type and agent-pair type. Both the population the pipeline enumerated
+and the subset it successfully characterized come from a single streaming pass over the cached feature
+artifacts.
+
+### What this produces
+
+Each run writes a timestamped folder under `output_dir` (default: `${paths.cache_path}/analysis`) with:
+- `dataset_counts.csv` — one row per dataset, every agent type and pair type, `total` and `valid` columns
+- `dataset_counts.json` — the same counts, nested by dataset label
+- `dataset_counts.tex` — booktabs table of the valid counts, ready to `\input` (needs `booktabs` and `graphicx`)
+- `trajectory_counts.png`, `interaction_counts.png` — grouped bars, one hue per dataset, log y-axis
+- `trajectory_composition.png`, `interaction_composition.png` — 100%-stacked bars of the class mix
+
+### Example usage
+
+Count a single dataset:
+```bash
+uv run python -m characterization.run_dataset_analysis paths=waymo_sample dataset=waymo
+```
+
+Count several datasets into one table, with LaTeX row labels:
+```bash
+uv run python -m characterization.run_dataset_analysis \
+    "datasets=[{label: Waymo, dataset_name: waymo, latex_label: '\womd~\cite{ettinger2021large}'}, \
+               {label: Argoverse2, dataset_name: argoverse2}, \
+               {label: nuPlan, dataset_name: nuplan}]"
+```
+
+Include the VRU-only pair types in the table and plots:
+```bash
+uv run python -m characterization.run_dataset_analysis \
+    latex_pair_types="[TYPE_VEHICLE_VEHICLE,TYPE_VEHICLE_PEDESTRIAN,TYPE_VEHICLE_CYCLIST,TYPE_PEDESTRIAN_PEDESTRIAN,TYPE_PEDESTRIAN_CYCLIST,TYPE_CYCLIST_CYCLIST]"
+```
+
+Emit exact numbers instead of `300k` / `3.6M`:
+```bash
+uv run python -m characterization.run_dataset_analysis latex_compact_numbers=false
+```
+
+### Useful config overrides
+
+Commonly overridden keys:
+- `features_path` (default: `${paths.cache_path}/features`)
+- `scenario_types`, `criteria` (exactly one of each — see Notes)
+- `total_scenarios` (limit scenario count for faster runs)
+- `latex_agent_types`, `latex_pair_types` (which types the table and plots render)
+- `latex_compact_numbers`, `count_scenarios_on_disk`
+- `output_dir`, `exp_tag`, `dpi`
+
+### Notes
+
+- **Exactly one `scenario_types` x `criteria` branch per run.** Feature artifacts are stored per branch,
+  so counting several would count every scenario once per branch. The script raises rather than
+  silently multiplying the numbers; re-run once per branch instead.
+- **`total` means enumerated by the pipeline, not present in the raw dataset.** For trajectories it is
+  the full `agent_types` list; for interactions it is every pair in `interaction_status`, which is
+  `C(N,2)` under the default `pair_scope=all` but only `N-1` when features were computed with
+  `pair_scope=ego`. Compare `num_scenarios_counted` against `num_scenarios_on_disk` to see whether
+  feature computation covered the whole dataset.
+- **A pair is valid when its `interaction_status` is `COMPUTED_OK` or `PARTIAL_INVALID_HEADING`** — the
+  same filter the interaction feature distributions use, so the counts match those plots exactly.
+- **The ego agent is counted in its own `TYPE_EGO_AGENT` trajectory bucket**, but `AgentPairType` has no
+  ego member and `get_agent_pair_type` folds ego into vehicle, so ego pairs land in V-V / V-P / V-C. The
+  CSV and JSON carry `pairs_with_ego_total` / `pairs_with_ego_valid` so this stays visible.
+- Composition plots take shares over the **selected** types only; excluding a type also removes it from
+  the denominator.
+
 ## Score Analysis
 
 The score analysis utility loads cached score/feature artifacts, computes scenario-level summaries,

--- a/src/characterization/config/run_analysis.yaml
+++ b/src/characterization/config/run_analysis.yaml
@@ -34,7 +34,8 @@ total_scenarios: null
 # Multi-dataset analysis. When set, each entry requires {label, dataset_name}.
 # All datasets use the same top-level scenario_types and criteria.
 # Per-dataset paths (features_path, scores_path) are derived by substituting dataset_name into
-# the existing path templates. Used by both run_feature_analysis.py and run_score_analysis.py.
+# the existing path templates. Used by run_feature_analysis.py, run_score_analysis.py, and
+# run_dataset_analysis.py.
 # Example:
 #   datasets:
 #     - label: Waymo
@@ -61,6 +62,28 @@ feature_categories:
     percentile_range: [75, 90]
   - name: CRITICAL
     percentile_range: [90, 100]
+
+# ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+# Dataset Analysis
+# ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+# Counts exactly one scenario_types x criteria branch; counting several would count every scenario once per branch.
+
+# Report how many scenario pickles exist under paths.scenario_base_path, to reveal scenarios that
+# feature computation skipped.
+count_scenarios_on_disk: true
+
+# Types rendered in dataset_counts.tex and the plots. All types are always present in the CSV/JSON.
+latex_agent_types:
+  - TYPE_VEHICLE
+  - TYPE_PEDESTRIAN
+  - TYPE_CYCLIST
+latex_pair_types:
+  - TYPE_VEHICLE_VEHICLE
+  - TYPE_VEHICLE_PEDESTRIAN
+  - TYPE_VEHICLE_CYCLIST
+
+# Render counts as 300k / 3.6M instead of 300,000 / 3,600,000.
+latex_compact_numbers: true
 
 # ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 # Score Analysis

--- a/src/characterization/run_dataset_analysis.py
+++ b/src/characterization/run_dataset_analysis.py
@@ -1,0 +1,147 @@
+r"""Entrypoint for counting trajectories and interactions per dataset from precomputed features.
+
+Streams the cached feature artifacts and reports, per agent type and per agent-pair type, both the
+population the pipeline enumerated and the subset it successfully characterized. Configuration is
+loaded from ``config/run_analysis.yaml`` by default.
+
+Supports both single-dataset and multi-dataset analysis. In multi-dataset mode (``cfg.datasets`` is
+set), every dataset contributes one row to a shared table.
+
+Example usage::
+    uv run python -m characterization.run_dataset_analysis
+
+    # Multi-dataset
+    uv run python -m characterization.run_dataset_analysis \\
+        "datasets=[{label: WOMD, dataset_name: waymo}, {label: nuPlan, dataset_name: nuplan}]"
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import hydra
+import pandas as pd
+from omegaconf import DictConfig
+
+from characterization.utils import analysis, common
+from characterization.utils.io_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+def _count_dataset(cfg: DictConfig, label: str, features_path: Path, scenario_base_path: Path) -> dict[str, object]:
+    """Counts one dataset's trajectories and interactions and returns a single table row.
+
+    Args:
+        cfg (DictConfig): Top-level configuration.
+        label (str): Display name for this dataset.
+        features_path (Path): Path to the directory containing this dataset's feature files.
+        scenario_base_path (Path): Path to this dataset's raw scenario pickles, used only to report how
+            many scenarios exist on disk versus how many were counted.
+
+    Returns:
+        dict[str, object]: One row of the counts table.
+
+    Raises:
+        ValueError: If no valid scenarios are found under *features_path*.
+    """
+    scenario_type, criterion = cfg.scenario_types[0], cfg.criteria[0]
+
+    scenario_ids = analysis.get_valid_scenario_ids([scenario_type], [criterion], features_path)
+    if not scenario_ids:
+        msg = f"No valid scenarios found in {features_path} for {scenario_type} and criterion {criterion}"
+        raise ValueError(msg)
+
+    total_scenarios = (
+        min(len(scenario_ids), cfg.total_scenarios)
+        if cfg.total_scenarios and cfg.total_scenarios > 0
+        else len(scenario_ids)
+    )
+    logger.info("Found %d valid scenarios for %s. Counting %d scenarios.", len(scenario_ids), label, total_scenarios)
+    scenario_ids = scenario_ids[:total_scenarios]
+
+    counts = analysis.count_dataset_features(scenario_ids, scenario_type, criterion, features_path)
+
+    row: dict[str, object] = {"dataset": label}
+    if cfg.count_scenarios_on_disk:
+        row["num_scenarios_on_disk"] = analysis.count_scenarios_on_disk(scenario_base_path)
+    row.update(counts)
+    return row
+
+
+@hydra.main(config_path="config", config_name="run_analysis", version_base="1.3")
+def run(cfg: DictConfig) -> None:
+    """Runs the dataset composition analysis using the provided configuration.
+
+    Writes ``dataset_counts.csv``, ``dataset_counts.json`` and ``dataset_counts.tex`` with one row per
+    dataset, plus grouped-bar count plots and 100%-stacked composition plots.
+
+    Args:
+        cfg (DictConfig): Configuration dictionary specifying feature paths and output options.
+
+    Raises:
+        ValueError: If unsupported scenario types are specified, or if more than one scenario type or
+            criterion is selected.
+    """
+    subdir = ""
+    if cfg.add_timestamp:
+        subdir = f"{datetime.now(tz=UTC).strftime('%Y%m%d_%H%M%S')}_"
+    subdir = f"{subdir}{cfg.exp_tag}" if cfg.exp_tag else subdir
+    output_dir = Path(cfg.output_dir) / subdir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Verify scenario types are supported
+    unsupported_scenario_types = [
+        scenario_type for scenario_type in cfg.scenario_types if scenario_type not in common.SUPPORTED_SCENARIO_TYPES
+    ]
+    if unsupported_scenario_types:
+        msg = f"Scenario types {unsupported_scenario_types} not in supported list {common.SUPPORTED_SCENARIO_TYPES}"
+        raise ValueError(msg)
+    # Counting several branches would count every scenario once per branch.
+    if len(cfg.scenario_types) != 1 or len(cfg.criteria) != 1:
+        msg = (
+            f"Dataset analysis counts exactly one scenario_type and one criterion, got "
+            f"{list(cfg.scenario_types)} and {list(cfg.criteria)}. Re-run once per branch."
+        )
+        raise ValueError(msg)
+
+    latex_labels: dict[str, str] = {}
+    if cfg.datasets is None:
+        rows = [
+            _count_dataset(cfg, cfg.paths.dataset_name, Path(cfg.features_path), Path(cfg.paths.scenario_base_path))
+        ]
+    else:
+        rows = []
+        for dataset_entry in cfg.datasets:
+            # Derive per-dataset paths by substituting dataset_name into the resolved path templates.
+            features_path = Path(str(cfg.features_path).replace(cfg.paths.dataset_name, dataset_entry.dataset_name))
+            scenario_base_path = Path(
+                str(cfg.paths.scenario_base_path).replace(cfg.paths.dataset_name, dataset_entry.dataset_name)
+            )
+            logger.info("Processing dataset: %s", dataset_entry.label)
+            rows.append(_count_dataset(cfg, dataset_entry.label, features_path, scenario_base_path))
+            if "latex_label" in dataset_entry:
+                latex_labels[dataset_entry.label] = dataset_entry.latex_label
+
+    counts_df = pd.DataFrame(rows)
+
+    output_filepath = output_dir / "dataset_counts.csv"
+    counts_df.to_csv(output_filepath, index=False)
+    logger.info("Saved dataset counts -> %s", output_filepath)
+
+    analysis.save_dataset_counts_json(counts_df, output_dir)
+
+    agent_types, pair_types = list(cfg.latex_agent_types), list(cfg.latex_pair_types)
+    analysis.write_latex_table(
+        counts_df,
+        output_dir / "dataset_counts.tex",
+        agent_types,
+        pair_types,
+        latex_labels,
+        compact_numbers=cfg.latex_compact_numbers,
+    )
+    analysis.plot_dataset_counts(counts_df, output_dir, agent_types, pair_types, cfg.dpi)
+    analysis.plot_dataset_composition(counts_df, output_dir, agent_types, pair_types, cfg.dpi)
+
+
+if __name__ == "__main__":
+    run()

--- a/src/characterization/utils/analysis/__init__.py
+++ b/src/characterization/utils/analysis/__init__.py
@@ -10,6 +10,16 @@ from characterization.utils.analysis.common_analysis import (
     get_valid_scenario_ids,
     plot_histograms_from_dataframe,
 )
+from characterization.utils.analysis.dataset_analysis import (
+    VALID_INTERACTION_STATUSES,
+    count_dataset_features,
+    count_scenario_features,
+    count_scenarios_on_disk,
+    plot_dataset_composition,
+    plot_dataset_counts,
+    save_dataset_counts_json,
+    write_latex_table,
+)
 from characterization.utils.analysis.feature_analysis import (
     load_features,
     load_scenario_features,
@@ -51,9 +61,13 @@ __all__ = [
     "DEFAULT_FEATURE_CATEGORIES",
     "FEATURE_COLOR_MAP",
     "SUPPORTED_FEATURES",
+    "VALID_INTERACTION_STATUSES",
     "build_probed_df",
     "compute_category_thresholds",
     "compute_jaccard_index",
+    "count_dataset_features",
+    "count_scenario_features",
+    "count_scenarios_on_disk",
     "get_sample_to_plot",
     "get_scenario_splits",
     "get_scored_scenario_ids",
@@ -68,6 +82,8 @@ __all__ = [
     "plot_agent_scores_heatmap",
     "plot_agent_scores_voxel",
     "plot_agent_scores_voxel_by_agent_type",
+    "plot_dataset_composition",
+    "plot_dataset_counts",
     "plot_feature_distributions",
     "plot_histograms_from_dataframe",
     "plot_multi_dataset_agent_score_distributions",
@@ -85,5 +101,7 @@ __all__ = [
     "regroup_individual_features",
     "regroup_interaction_features",
     "regroup_scenario_scores",
+    "save_dataset_counts_json",
     "save_probe_summary_json",
+    "write_latex_table",
 ]

--- a/src/characterization/utils/analysis/dataset_analysis.py
+++ b/src/characterization/utils/analysis/dataset_analysis.py
@@ -1,0 +1,391 @@
+"""Counts individual trajectories and interaction pairs per dataset from cached feature artifacts.
+
+Both the "considered" and the "valid" population are recovered from a single pass over the feature
+pickles: ``Individual.agent_types`` is the full per-scenario agent list while ``valid_idxs`` selects
+the agents that survived feature computation, and ``Interaction.interaction_agent_types`` covers every
+enumerated pair while ``interaction_status`` records why a pair was discarded.
+"""
+
+import json
+from collections import Counter
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from matplotlib.container import BarContainer
+from tqdm import tqdm
+
+from characterization.schemas import ScenarioFeatures
+from characterization.utils.analysis.common_analysis import AGENT_COLORS, get_dataset_colors
+from characterization.utils.common import InteractionStatus
+from characterization.utils.io_utils import from_pickle, get_logger
+from characterization.utils.scenario_types import AgentPairType, AgentType, get_agent_pair_type
+
+logger = get_logger(__name__)
+
+# A pair is "valid" when its features were computed. PARTIAL_INVALID_HEADING pairs have valid
+# separation/intersection/collision/mTTCP values, so they are counted here exactly as they are counted
+# by regroup_interaction_features.
+VALID_INTERACTION_STATUSES = frozenset({InteractionStatus.COMPUTED_OK, InteractionStatus.PARTIAL_INVALID_HEADING})
+
+COUNTED_AGENT_TYPES: tuple[AgentType, ...] = tuple(AgentType)
+COUNTED_PAIR_TYPES: tuple[AgentPairType, ...] = tuple(AgentPairType)
+
+# Short column headers used by the LaTeX table.
+_LATEX_SHORT_NAMES: dict[str, str] = {
+    "TYPE_VEHICLE": "V",
+    "TYPE_PEDESTRIAN": "P",
+    "TYPE_CYCLIST": "C",
+    "TYPE_EGO_AGENT": "E",
+    "TYPE_VEHICLE_VEHICLE": "V-V",
+    "TYPE_VEHICLE_PEDESTRIAN": "V-P",
+    "TYPE_VEHICLE_CYCLIST": "V-C",
+    "TYPE_PEDESTRIAN_PEDESTRIAN": "P-P",
+    "TYPE_PEDESTRIAN_CYCLIST": "P-C",
+    "TYPE_CYCLIST_CYCLIST": "C-C",
+}
+
+
+def _empty_counts() -> dict[str, int]:
+    """Returns a counts dict with every agent-type and pair-type column initialized to zero."""
+    counts = {"pairs_with_ego_total": 0, "pairs_with_ego_valid": 0}
+    for agent_type in COUNTED_AGENT_TYPES:
+        counts[f"agents_total_{agent_type.name}"] = 0
+        counts[f"agents_valid_{agent_type.name}"] = 0
+    for pair_type in COUNTED_PAIR_TYPES:
+        counts[f"pairs_total_{pair_type.name}"] = 0
+        counts[f"pairs_valid_{pair_type.name}"] = 0
+    return counts
+
+
+def count_scenario_features(features: ScenarioFeatures) -> dict[str, int]:
+    """Counts trajectories and interaction pairs in a single scenario, by type and by validity.
+
+    Args:
+        features (ScenarioFeatures): Feature artifact for one scenario. Either half may be ``None`` if
+            only individual or only interaction features were computed; missing halves count as zero.
+
+    Returns:
+        dict[str, int]: Flat counts keyed by ``agents_{total,valid}_<AGENT_TYPE>``,
+            ``pairs_{total,valid}_<AGENT_PAIR_TYPE>``, and ``pairs_with_ego_{total,valid}``.
+    """
+    counts = _empty_counts()
+
+    individual = features.individual_features
+    if individual is not None and individual.agent_types is not None:
+        agent_types = individual.agent_types
+        for agent_type, count in Counter(agent_types).items():
+            counts[f"agents_total_{agent_type.name}"] += count
+        if individual.valid_idxs is not None:
+            valid_types = Counter(agent_types[i] for i in individual.valid_idxs)
+            for agent_type, count in valid_types.items():
+                counts[f"agents_valid_{agent_type.name}"] += count
+
+    interaction = features.interaction_features
+    if interaction is not None and interaction.interaction_agent_types is not None:
+        # interaction_agent_types and interaction_status are parallel arrays over every enumerated pair.
+        statuses = interaction.interaction_status or [InteractionStatus.UNKNOWN] * len(
+            interaction.interaction_agent_types
+        )
+        for (type_a, type_b), status in zip(interaction.interaction_agent_types, statuses, strict=True):
+            pair_type = get_agent_pair_type(type_a, type_b)
+            is_valid = status in VALID_INTERACTION_STATUSES
+            # AgentPairType has no ego member -- get_agent_pair_type folds ego into vehicle -- so ego
+            # involvement is tracked separately to keep it visible.
+            has_ego = int(AgentType.TYPE_EGO_AGENT in (type_a, type_b))
+            counts[f"pairs_total_{pair_type.name}"] += 1
+            counts["pairs_with_ego_total"] += has_ego
+            if is_valid:
+                counts[f"pairs_valid_{pair_type.name}"] += 1
+                counts["pairs_with_ego_valid"] += has_ego
+
+    return counts
+
+
+def count_dataset_features(
+    scenario_ids: list[str],
+    scenario_type: str,
+    criterion: str,
+    features_path: Path,
+) -> dict[str, int]:
+    """Accumulates per-scenario counts across a dataset, loading one feature artifact at a time.
+
+    Streams rather than reusing ``load_scenario_features``, which retains every scenario's full feature
+    set in memory. Only one ``(scenario_type, criterion)`` branch is counted; counting several would
+    multiply every scenario.
+
+    Args:
+        scenario_ids (list[str]): Scenario file names to count, as returned by ``get_valid_scenario_ids``.
+        scenario_type (str): Scenario type branch (e.g. ``gt``).
+        criterion (str): Criterion branch (e.g. ``critical_continuous``).
+        features_path (Path): Path to the directory containing the per-branch feature directories.
+
+    Returns:
+        dict[str, int]: Accumulated counts plus ``num_scenarios_counted``.
+    """
+    key = f"{scenario_type}_{criterion}"
+    branch_path = features_path / key
+
+    totals = _empty_counts()
+    for scenario_id in tqdm(scenario_ids, desc=f"Counting {key} features"):
+        features = from_pickle(str(branch_path / scenario_id))  # nosec B301
+        counts = count_scenario_features(ScenarioFeatures.model_validate(features))
+        for column, value in counts.items():
+            totals[column] += value
+
+    totals["num_scenarios_counted"] = len(scenario_ids)
+    return totals
+
+
+def count_scenarios_on_disk(scenario_base_path: Path) -> int | None:
+    """Counts scenario pickles present on disk, to reveal scenarios that feature computation skipped.
+
+    Args:
+        scenario_base_path (Path): Directory holding the raw scenario pickles.
+
+    Returns:
+        int | None: Number of ``.pkl`` files found, or ``None`` if the directory does not exist.
+    """
+    if not scenario_base_path.is_dir():
+        logger.warning("Scenario path %s does not exist; skipping on-disk scenario count", scenario_base_path)
+        return None
+    return sum(1 for _ in scenario_base_path.rglob("*.pkl"))
+
+
+def save_dataset_counts_json(counts_df: pd.DataFrame, output_dir: Path) -> None:
+    """Writes the per-dataset counts to ``dataset_counts.json``, nested by dataset label.
+
+    Args:
+        counts_df (pd.DataFrame): One row per dataset, with a ``dataset`` column.
+        output_dir (Path): Directory to write the JSON file.
+    """
+    summary = {row["dataset"]: {k: v for k, v in row.items() if k != "dataset"} for row in counts_df.to_dict("records")}
+    output_filepath = output_dir / "dataset_counts.json"
+    output_filepath.write_text(json.dumps(summary, indent=2))
+    logger.info("Saved dataset counts -> %s", output_filepath)
+
+
+THOUSAND = 1_000
+TEN_THOUSAND = 10_000
+MILLION = 1_000_000
+
+
+def _format_count(value: int, *, compact: bool) -> str:
+    """Renders a count as ``3.6M`` / ``300k`` / ``2.4k`` when *compact*, else with thousands separators.
+
+    Values below ten thousand keep one decimal, so that e.g. 1,500 and 2,419 stay distinguishable.
+    """
+    if not compact or value < THOUSAND:
+        return f"{value:,}"
+    if value < TEN_THOUSAND:
+        return f"{value / 1e3:.1f}k"
+    if value < MILLION:
+        return f"{value / 1e3:.0f}k"
+    return f"{value / 1e6:.1f}M"
+
+
+def write_latex_table(
+    counts_df: pd.DataFrame,
+    output_path: Path,
+    agent_types: list[str],
+    pair_types: list[str],
+    labels: dict[str, str] | None = None,
+    *,
+    compact_numbers: bool = True,
+) -> None:
+    r"""Writes a booktabs table of valid trajectory and interaction counts, one row per dataset.
+
+    Hand-rolled rather than ``DataFrame.to_latex`` because the layout needs ``\multicolumn`` group
+    headers and ``\cmidrule`` spans. Requires ``booktabs`` and ``graphicx`` in the document preamble.
+
+    Args:
+        counts_df (pd.DataFrame): One row per dataset, as written to ``dataset_counts.csv``.
+        output_path (Path): File to write the LaTeX fragment to.
+        agent_types (list[str]): ``AgentType`` names to render as trajectory columns.
+        pair_types (list[str]): ``AgentPairType`` names to render as interaction columns.
+        labels (dict[str, str] | None): Optional dataset label -> LaTeX row label (e.g. a ``\cite``
+            macro). Datasets absent from the mapping fall back to their plain label.
+        compact_numbers (bool): Render counts as ``300k`` / ``3.6M`` instead of ``300,000``.
+    """
+    labels = labels or {}
+    num_agent_cols, num_pair_cols = len(agent_types), len(pair_types)
+    # Columns 1 and 2 are the dataset name and the scenario count; the groups follow.
+    agent_span = (3, 2 + num_agent_cols)
+    pair_span = (3 + num_agent_cols, 2 + num_agent_cols + num_pair_cols)
+
+    headers = [_LATEX_SHORT_NAMES.get(name, name) for name in (*agent_types, *pair_types)]
+    lines = [
+        r"\begin{table}[h]",
+        r"    \centering",
+        r"    \small",
+        r"    \resizebox{\columnwidth}{!}{%",
+        rf"    \begin{{tabular}}{{lc{'r' * (num_agent_cols + num_pair_cols)}}}",
+        r"        \toprule",
+        rf"        & & \multicolumn{{{num_agent_cols}}}{{c}}{{\textbf{{Trajectories}}}} "
+        rf"& \multicolumn{{{num_pair_cols}}}{{c}}{{\textbf{{Interactions}}}} \\",
+        rf"        \cmidrule(lr){{{agent_span[0]}-{agent_span[1]}}} "
+        rf"\cmidrule(lr){{{pair_span[0]}-{pair_span[1]}}}",
+        r"        \textbf{Dataset} & \textbf{Scenarios} & " + " & ".join(headers) + r" \\",
+        r"        \midrule",
+    ]
+
+    for row in counts_df.to_dict("records"):
+        label = labels.get(str(row["dataset"]), str(row["dataset"]))
+        cells = [f"{int(row['num_scenarios_counted']):,}"]
+        cells += [_format_count(int(row[f"agents_valid_{name}"]), compact=compact_numbers) for name in agent_types]
+        cells += [_format_count(int(row[f"pairs_valid_{name}"]), compact=compact_numbers) for name in pair_types]
+        lines.append(f"        {label} & " + " & ".join(cells) + r" \\")
+
+    lines += [
+        r"        \bottomrule",
+        r"    \end{tabular}",
+        r"    }",
+        r"    \caption{Valid individual trajectories and interaction counts per dataset. "
+        r"The ego agent is counted in its own trajectory column where present; on the interaction side "
+        r"it is folded into the vehicle pair types.}",
+        r"    \label{tab:experimental_setup}",
+        r"\end{table}",
+        "",
+    ]
+    output_path.write_text("\n".join(lines))
+    logger.info("Saved LaTeX counts table -> %s", output_path)
+
+
+def _set_theme() -> None:
+    """Applies the shared analysis plot theme."""
+    sns.set_theme(
+        style="whitegrid",
+        font_scale=0.9,
+        rc={
+            "grid.linestyle": "--",
+            "grid.alpha": 0.3,
+            "font.family": "sans-serif",
+            "font.sans-serif": ["DejaVu Sans"],
+        },
+    )
+
+
+def _long_form(counts_df: pd.DataFrame, prefix: str, type_names: list[str]) -> pd.DataFrame:
+    """Reshapes the wide counts table into ``dataset`` / ``type`` / ``count`` rows for seaborn."""
+    records = [
+        {
+            "dataset": str(row["dataset"]),
+            "type": _LATEX_SHORT_NAMES.get(name, name),
+            "count": int(row[f"{prefix}{name}"]),
+        }
+        for row in counts_df.to_dict("records")
+        for name in type_names
+    ]
+    return pd.DataFrame(records)
+
+
+def plot_dataset_counts(
+    counts_df: pd.DataFrame,
+    output_dir: Path,
+    agent_types: list[str],
+    pair_types: list[str],
+    dpi: int = 300,
+) -> None:
+    """Plots valid trajectory and interaction counts as grouped bars, one hue per dataset.
+
+    Args:
+        counts_df (pd.DataFrame): One row per dataset, as written to ``dataset_counts.csv``.
+        output_dir (Path): Directory to save the output plots.
+        agent_types (list[str]): ``AgentType`` names to plot on the trajectory chart.
+        pair_types (list[str]): ``AgentPairType`` names to plot on the interaction chart.
+        dpi (int): Dots per inch for the saved figures.
+    """
+    _set_theme()
+    dataset_labels = [str(label) for label in counts_df["dataset"]]
+    palette = get_dataset_colors(dataset_labels)
+
+    for prefix, type_names, title, filename in [
+        ("agents_valid_", agent_types, "Valid Trajectories per Dataset", "trajectory_counts.png"),
+        ("pairs_valid_", pair_types, "Valid Interactions per Dataset", "interaction_counts.png"),
+    ]:
+        df = _long_form(counts_df, prefix, type_names)
+        _, ax = plt.subplots(1, 1, figsize=(10, 6))
+        sns.barplot(data=df, x="type", y="count", hue="dataset", palette=palette, ax=ax)
+        # Counts span several orders of magnitude across agent types.
+        ax.set_yscale("log")
+        for container in ax.containers:
+            if isinstance(container, BarContainer):
+                ax.bar_label(container, fmt=lambda v: _format_count(int(v), compact=True), fontsize=7, padding=2)
+
+        sns.despine(top=True, right=True)
+        ax.set_xlabel("")
+        ax.set_ylabel("Count (log scale)")
+        ax.set_title(title)
+        ax.grid(visible=True, linestyle="--", alpha=0.4)
+        ax.legend(title="Dataset", fontsize=8)
+
+        plt.tight_layout()
+        output_filepath = output_dir / filename
+        plt.savefig(output_filepath, dpi=dpi)
+        plt.close()
+        logger.info("Saved %s -> %s", title.lower(), output_filepath)
+
+
+def plot_dataset_composition(
+    counts_df: pd.DataFrame,
+    output_dir: Path,
+    agent_types: list[str],
+    pair_types: list[str],
+    dpi: int = 300,
+) -> None:
+    """Plots each dataset's class mix as 100%-stacked bars, making imbalance comparable across datasets.
+
+    Shares are taken over the selected types only, so excluding a type also removes it from the
+    denominator.
+
+    Args:
+        counts_df (pd.DataFrame): One row per dataset, as written to ``dataset_counts.csv``.
+        output_dir (Path): Directory to save the output plots.
+        agent_types (list[str]): ``AgentType`` names to stack on the trajectory chart.
+        pair_types (list[str]): ``AgentPairType`` names to stack on the interaction chart.
+        dpi (int): Dots per inch for the saved figures.
+    """
+    _set_theme()
+    dataset_labels = [str(label) for label in counts_df["dataset"]]
+
+    for prefix, type_names, enum_cls, title, filename in [
+        ("agents_valid_", agent_types, AgentType, "Trajectory Composition", "trajectory_composition.png"),
+        ("pairs_valid_", pair_types, AgentPairType, "Interaction Composition", "interaction_composition.png"),
+    ]:
+        counts = np.asarray(
+            [[int(row[f"{prefix}{name}"]) for name in type_names] for row in counts_df.to_dict("records")],
+            dtype=np.float64,
+        )
+        totals = counts.sum(axis=1, keepdims=True)
+        shares = np.divide(counts, totals, out=np.zeros_like(counts), where=totals > 0) * 100.0
+
+        _, ax = plt.subplots(1, 1, figsize=(10, 6))
+        bottom = np.zeros(len(dataset_labels))
+        for column, name in enumerate(type_names):
+            color = AGENT_COLORS.get(enum_cls[name], "gray")
+            bars = ax.bar(
+                dataset_labels,
+                shares[:, column],
+                bottom=bottom,
+                color=color,
+                label=_LATEX_SHORT_NAMES.get(name, name),
+                edgecolor="white",
+            )
+            ax.bar_label(bars, fmt=lambda v: f"{v:.1f}%" if v >= 1.0 else "", label_type="center", fontsize=7)
+            bottom += shares[:, column]
+
+        sns.despine(top=True, right=True)
+        ax.set_xlabel("")
+        ax.set_ylabel("Share of selected types (%)")
+        ax.set_ylim(0, 100)
+        ax.set_title(title)
+        ax.grid(visible=True, axis="y", linestyle="--", alpha=0.4)
+        ax.legend(title="Type", fontsize=8)
+
+        plt.tight_layout()
+        output_filepath = output_dir / filename
+        plt.savefig(output_filepath, dpi=dpi)
+        plt.close()
+        logger.info("Saved %s -> %s", title.lower(), output_filepath)

--- a/tests/test_dataset_analysis.py
+++ b/tests/test_dataset_analysis.py
@@ -1,0 +1,141 @@
+"""Tests for per-dataset trajectory and interaction counting."""
+
+import numpy as np
+
+from characterization.schemas.scenario import ScenarioMetadata
+from characterization.schemas.scenario_features import Individual, Interaction, ScenarioFeatures
+from characterization.utils.analysis import count_scenario_features
+from characterization.utils.common import InteractionStatus, TrajectoryType
+from characterization.utils.scenario_types import AgentType
+
+# Agents 0..3: ego, vehicle, pedestrian, cyclist. Agent 2 (pedestrian) fails the validity gate.
+AGENT_TYPES = [
+    AgentType.TYPE_EGO_AGENT,
+    AgentType.TYPE_VEHICLE,
+    AgentType.TYPE_PEDESTRIAN,
+    AgentType.TYPE_CYCLIST,
+]
+VALID_IDXS = np.asarray([0, 1, 3], dtype=np.int32)
+AGENT_PAIRS = [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
+PAIR_STATUSES = [
+    InteractionStatus.COMPUTED_OK,
+    InteractionStatus.PARTIAL_INVALID_HEADING,
+    InteractionStatus.DISTANCE_TOO_FAR,
+    InteractionStatus.MASK_NOT_VALID,
+    InteractionStatus.COMPUTED_OK,
+    InteractionStatus.COMPUTED_OK,
+]
+
+
+def _metadata() -> ScenarioMetadata:
+    return ScenarioMetadata(
+        scenario_id="counts-test",
+        timestamps_seconds=[0.0, 1.0],
+        frequency_hz=1.0,
+        current_time_index=0,
+        ego_vehicle_id=0,
+        ego_vehicle_index=0,
+        objects_of_interest=[],
+        track_length=2,
+        dataset="test",
+    )
+
+
+def _features(*, with_individual: bool = True, with_interaction: bool = True) -> ScenarioFeatures:
+    individual = None
+    if with_individual:
+        individual = Individual(
+            valid_idxs=VALID_IDXS,
+            agent_types=AGENT_TYPES,
+            agent_trajectory_types=[TrajectoryType.TYPE_STRAIGHT] * len(VALID_IDXS),
+        )
+
+    interaction = None
+    if with_interaction:
+        interaction = Interaction(
+            interaction_agent_indices=AGENT_PAIRS,
+            interaction_agent_types=[(AGENT_TYPES[i], AGENT_TYPES[j]) for i, j in AGENT_PAIRS],
+            interaction_status=PAIR_STATUSES,
+        )
+
+    return ScenarioFeatures(metadata=_metadata(), individual_features=individual, interaction_features=interaction)
+
+
+def _nonzero(counts: dict[str, int], prefix: str) -> dict[str, int]:
+    """Returns the non-zero counts under *prefix*, with the prefix stripped from each key."""
+    return {key.removeprefix(prefix): value for key, value in counts.items() if key.startswith(prefix) and value}
+
+
+def test_agents_split_by_type_with_ego_separate() -> None:
+    """Every agent is counted under its own type, and the ego keeps its own bucket."""
+    counts = count_scenario_features(_features())
+
+    assert _nonzero(counts, "agents_total_") == {
+        "TYPE_EGO_AGENT": 1,
+        "TYPE_VEHICLE": 1,
+        "TYPE_PEDESTRIAN": 1,
+        "TYPE_CYCLIST": 1,
+    }
+
+
+def test_valid_agents_follow_valid_idxs() -> None:
+    """Valid counts subset the full agent list through valid_idxs, dropping agent 2."""
+    counts = count_scenario_features(_features())
+
+    assert _nonzero(counts, "agents_valid_") == {
+        "TYPE_EGO_AGENT": 1,
+        "TYPE_VEHICLE": 1,
+        "TYPE_CYCLIST": 1,
+    }
+
+
+def test_pairs_bucket_by_pair_type_with_ego_folded_into_vehicle() -> None:
+    """Total pair counts cover every enumerated pair, with ego pairs typed as vehicle pairs."""
+    counts = count_scenario_features(_features())
+
+    assert _nonzero(counts, "pairs_total_") == {
+        "TYPE_VEHICLE_VEHICLE": 1,  # (ego, vehicle)
+        "TYPE_VEHICLE_PEDESTRIAN": 2,  # (ego, ped), (vehicle, ped)
+        "TYPE_VEHICLE_CYCLIST": 2,  # (ego, cyclist), (vehicle, cyclist)
+        "TYPE_PEDESTRIAN_CYCLIST": 1,  # (ped, cyclist)
+    }
+
+
+def test_only_computed_statuses_count_as_valid_pairs() -> None:
+    """COMPUTED_OK and PARTIAL_INVALID_HEADING count; TOO_FAR and MASK_NOT_VALID do not."""
+    counts = count_scenario_features(_features())
+
+    assert _nonzero(counts, "pairs_valid_") == {
+        "TYPE_VEHICLE_VEHICLE": 1,  # (ego, vehicle) OK
+        "TYPE_VEHICLE_PEDESTRIAN": 1,  # (ego, ped) PARTIAL; (vehicle, ped) MASK_NOT_VALID
+        "TYPE_VEHICLE_CYCLIST": 1,  # (ego, cyclist) TOO_FAR; (vehicle, cyclist) OK
+        "TYPE_PEDESTRIAN_CYCLIST": 1,  # (ped, cyclist) OK
+    }
+
+
+def test_ego_pairs_tracked_separately() -> None:
+    """Ego involvement is reported alongside the pair-type buckets that hide it."""
+    counts = count_scenario_features(_features())
+
+    assert _nonzero(counts, "pairs_with_ego_") == {"total": 3, "valid": 2}
+
+
+def test_missing_halves_count_as_zero() -> None:
+    """A feature artifact holding only one half still counts, with zeros for the other."""
+    individual_only = count_scenario_features(_features(with_interaction=False))
+    assert _nonzero(individual_only, "agents_total_") == {
+        "TYPE_EGO_AGENT": 1,
+        "TYPE_VEHICLE": 1,
+        "TYPE_PEDESTRIAN": 1,
+        "TYPE_CYCLIST": 1,
+    }
+    assert _nonzero(individual_only, "pairs_") == {}
+
+    interaction_only = count_scenario_features(_features(with_individual=False))
+    assert _nonzero(interaction_only, "pairs_total_") == {
+        "TYPE_VEHICLE_VEHICLE": 1,
+        "TYPE_VEHICLE_PEDESTRIAN": 2,
+        "TYPE_VEHICLE_CYCLIST": 2,
+        "TYPE_PEDESTRIAN_CYCLIST": 1,
+    }
+    assert _nonzero(interaction_only, "agents_") == {}

--- a/uv.lock
+++ b/uv.lock
@@ -2222,7 +2222,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.5.1.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (python_full_version < '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/78/4535c9c7f859a64781e43c969a3a7e84c54634e319a996d43ef32ce46f83/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2", size = 570988386, upload-time = "2024-10-25T19:54:26.39Z" },
@@ -2233,7 +2233,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (python_full_version < '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/16/73727675941ab8e6ffd86ca3a4b7b47065edcca7a997920b831f8147c99d/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5", size = 200221632, upload-time = "2024-11-20T17:41:32.357Z" },
@@ -2262,9 +2262,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (python_full_version < '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "nvidia-cusparse-cu12", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (python_full_version < '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (python_full_version < '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/6e/c2cf12c9ff8b872e92b4a5740701e51ff17689c4d726fca91875b07f655d/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c", size = 158229790, upload-time = "2024-11-20T17:43:43.211Z" },
@@ -2276,7 +2276,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.12' and sys_platform == 'darwin') or (python_full_version < '3.12' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/1e/b8b7c2f4099a37b96af5c9bb158632ea9e5d9d27d7391d7eb8fc45236674/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73", size = 216561367, upload-time = "2024-11-20T17:44:54.824Z" },
@@ -3478,7 +3478,7 @@ wheels = [
 
 [[package]]
 name = "scenario-characterization"
-version = "0.4.1"
+version = "0.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },
@@ -4353,8 +4353,8 @@ name = "triton"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", version = "67.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "setuptools", version = "67.6.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/a9/549e51e9b1b2c9b854fd761a1d23df0ba2fbc60bd0c13b489ffa518cfcb7/triton-3.3.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b74db445b1c562844d3cfad6e9679c72e93fdfb1a90a24052b03bb5c49d1242e", size = 155600257, upload-time = "2025-05-29T23:39:36.085Z" },


### PR DESCRIPTION
This pull request introduces a new dataset analysis utility to the characterization pipeline, enabling users to count and analyze the number of individual trajectories and interaction pairs per dataset, broken down by agent and pair type. It includes a new entrypoint script, updates to the configuration, and exposes new analysis functions. The documentation is updated to describe usage, output, and configuration options.

Key changes include:

**New dataset analysis functionality:**

- Added a new script, `run_dataset_analysis.py`, which streams cached feature artifacts to count trajectories and interactions per dataset, writes summary tables (CSV, JSON, LaTeX), and generates visualizations. The script supports both single and multi-dataset analysis and is configurable via `run_analysis.yaml`.
- Exposed new analysis functions (e.g., `count_dataset_features`, `plot_dataset_counts`, `write_latex_table`) in the `characterization.utils.analysis` module for use by the new entrypoint and potentially other tools. [[1]](diffhunk://#diff-8fd0de1195a2cc7669e03d3997a27b67136718b733d0f6fa0e1f18e3595b24f4R13-R22) [[2]](diffhunk://#diff-8fd0de1195a2cc7669e03d3997a27b67136718b733d0f6fa0e1f18e3595b24f4R64-R70) [[3]](diffhunk://#diff-8fd0de1195a2cc7669e03d3997a27b67136718b733d0f6fa0e1f18e3595b24f4R85-R86) [[4]](diffhunk://#diff-8fd0de1195a2cc7669e03d3997a27b67136718b733d0f6fa0e1f18e3595b24f4R104-R106)

**Configuration and documentation updates:**

- Updated `run_analysis.yaml` to add configuration options for dataset analysis, including agent/pair types, compact number formatting, and scenario counting options.
- Clarified in the config that multi-dataset analysis is now used by `run_dataset_analysis.py` as well as the existing scripts.
- Expanded `docs/ANALYSIS.md` with a new section describing the dataset analysis utility, its outputs, example usages, and configuration notes.