### PR TITLE
Standardize dataset color conventions across analyses

### DIFF
--- a/src/characterization/run_dataset_analysis.py
+++ b/src/characterization/run_dataset_analysis.py
@@ -13,6 +13,12 @@ Example usage::
     # Multi-dataset
     uv run python -m characterization.run_dataset_analysis \\
         "datasets=[{label: WOMD, dataset_name: waymo}, {label: nuPlan, dataset_name: nuplan}]"
+
+    # Multi-dataset with LaTeX row labels. Single-quote each label so YAML keeps the backslashes.
+    uv run python -m characterization.run_dataset_analysis output_dir=./outputs/dataset_analysis \\
+        "datasets=[{label: WOMD, dataset_name: waymo, latex_label: '\womd'}, \\
+                   {label: Argoverse2, dataset_name: argoverse2, latex_label: '\argoverse'}, \\
+                   {label: nuPlan, dataset_name: nuplan, latex_label: '\nuplan'}]"
 """
 
 from datetime import UTC, datetime
@@ -28,12 +34,19 @@ from characterization.utils.io_utils import get_logger
 logger = get_logger(__name__)
 
 
-def _count_dataset(cfg: DictConfig, label: str, features_path: Path, scenario_base_path: Path) -> dict[str, object]:
+def _count_dataset(
+    cfg: DictConfig,
+    label: str,
+    dataset_name: str,
+    features_path: Path,
+    scenario_base_path: Path,
+) -> dict[str, object]:
     """Counts one dataset's trajectories and interactions and returns a single table row.
 
     Args:
         cfg (DictConfig): Top-level configuration.
         label (str): Display name for this dataset.
+        dataset_name (str): Canonical dataset name, used to resolve plot colors independently of *label*.
         features_path (Path): Path to the directory containing this dataset's feature files.
         scenario_base_path (Path): Path to this dataset's raw scenario pickles, used only to report how
             many scenarios exist on disk versus how many were counted.
@@ -61,7 +74,7 @@ def _count_dataset(cfg: DictConfig, label: str, features_path: Path, scenario_ba
 
     counts = analysis.count_dataset_features(scenario_ids, scenario_type, criterion, features_path)
 
-    row: dict[str, object] = {"dataset": label}
+    row: dict[str, object] = {"dataset": label, "dataset_name": dataset_name}
     if cfg.count_scenarios_on_disk:
         row["num_scenarios_on_disk"] = analysis.count_scenarios_on_disk(scenario_base_path)
     row.update(counts)
@@ -107,7 +120,13 @@ def run(cfg: DictConfig) -> None:
     latex_labels: dict[str, str] = {}
     if cfg.datasets is None:
         rows = [
-            _count_dataset(cfg, cfg.paths.dataset_name, Path(cfg.features_path), Path(cfg.paths.scenario_base_path))
+            _count_dataset(
+                cfg,
+                cfg.paths.dataset_name,
+                cfg.paths.dataset_name,
+                Path(cfg.features_path),
+                Path(cfg.paths.scenario_base_path),
+            )
         ]
     else:
         rows = []
@@ -118,7 +137,9 @@ def run(cfg: DictConfig) -> None:
                 str(cfg.paths.scenario_base_path).replace(cfg.paths.dataset_name, dataset_entry.dataset_name)
             )
             logger.info("Processing dataset: %s", dataset_entry.label)
-            rows.append(_count_dataset(cfg, dataset_entry.label, features_path, scenario_base_path))
+            rows.append(
+                _count_dataset(cfg, dataset_entry.label, dataset_entry.dataset_name, features_path, scenario_base_path)
+            )
             if "latex_label" in dataset_entry:
                 latex_labels[dataset_entry.label] = dataset_entry.latex_label
 

--- a/src/characterization/utils/analysis/dataset_analysis.py
+++ b/src/characterization/utils/analysis/dataset_analysis.py
@@ -267,6 +267,19 @@ def _set_theme() -> None:
     )
 
 
+def _palette_by_label(counts_df: pd.DataFrame) -> dict[str, str]:
+    """Maps each dataset's display label to the color of its canonical ``dataset_name``.
+
+    Colors are resolved from ``dataset_name`` rather than from ``dataset`` so that a dataset keeps the
+    same color as in the feature and score analyses no matter what display label it is given. Falls back
+    to the label when ``dataset_name`` is absent (e.g. a CSV written before that column existed).
+    """
+    labels = [str(label) for label in counts_df["dataset"]]
+    names = [str(name) for name in counts_df["dataset_name"]] if "dataset_name" in counts_df else labels
+    colors_by_name = get_dataset_colors(names)
+    return {label: colors_by_name[name] for label, name in zip(labels, names, strict=True)}
+
+
 def _long_form(counts_df: pd.DataFrame, prefix: str, type_names: list[str]) -> pd.DataFrame:
     """Reshapes the wide counts table into ``dataset`` / ``type`` / ``count`` rows for seaborn."""
     records = [
@@ -298,8 +311,7 @@ def plot_dataset_counts(
         dpi (int): Dots per inch for the saved figures.
     """
     _set_theme()
-    dataset_labels = [str(label) for label in counts_df["dataset"]]
-    palette = get_dataset_colors(dataset_labels)
+    palette = _palette_by_label(counts_df)
 
     for prefix, type_names, title, filename in [
         ("agents_valid_", agent_types, "Valid Trajectories per Dataset", "trajectory_counts.png"),


### PR DESCRIPTION
This pull request enhances the dataset analysis pipeline by improving how datasets are identified and visualized, ensuring consistent color mapping and more robust handling of dataset labels and names. The main changes include passing canonical dataset names throughout the analysis, updating the output data structure, and improving plotting consistency.

**Dataset identification and output structure:**
- The `_count_dataset` function now accepts and stores both a display `label` and a canonical `dataset_name`, ensuring that both are available for downstream processing and output. [[1]](diffhunk://#diff-3722c7fb4d16cc4ee05ece4e8e76d1b0d52a2d3451e4658379a69925d5534f9cL31-R49) [[2]](diffhunk://#diff-3722c7fb4d16cc4ee05ece4e8e76d1b0d52a2d3451e4658379a69925d5534f9cL64-R77) [[3]](diffhunk://#diff-3722c7fb4d16cc4ee05ece4e8e76d1b0d52a2d3451e4658379a69925d5534f9cL110-R129) [[4]](diffhunk://#diff-3722c7fb4d16cc4ee05ece4e8e76d1b0d52a2d3451e4658379a69925d5534f9cL121-R142)

**Visualization improvements:**
- Introduced the `_palette_by_label` function to map display labels to colors based on their canonical `dataset_name`, ensuring consistent color usage across analyses regardless of label changes.
- Updated the `plot_dataset_counts` function to use the new palette mapping, further enforcing color consistency in plots.

**Documentation and usability:**
- Expanded the usage example in `run_dataset_analysis.py` to demonstrate how to specify LaTeX row labels for datasets, clarifying YAML syntax for special characters.