### PR TITLE
chore(interaction): make closest-distance chunking configurable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scenario-characterization"
-version = "0.4.7"
+version = "0.4.8"
 authors = [
     {name="Ingrid Navarro", email="ingridn@cmu.edu"},
     {name="Duan Yutong (dyt-stackav)"},

--- a/src/characterization/config/characterizer/default.yaml
+++ b/src/characterization/config/characterizer/default.yaml
@@ -32,6 +32,7 @@ processor:
 
 characterizer:
   config:
+    chunk_size: ${chunk_size}
     feature_type: ${feature_type}
     include_pairs_with_no_vehicles: ${include_pairs_with_no_vehicles}
 

--- a/src/characterization/config/run_processor.yaml
+++ b/src/characterization/config/run_processor.yaml
@@ -20,6 +20,8 @@ parallel: true
 batch_size: 8
 num_workers: 8
 shuffle: false
+# Number of agents processed per closest-distance chunk. Null uses the shared code default.
+chunk_size: null
 
 scenario_type: 'gt'
 return_criterion: 'critical'

--- a/src/characterization/features/base_feature.py
+++ b/src/characterization/features/base_feature.py
@@ -19,6 +19,7 @@ class BaseFeature(ABC):
         features (Any): Feature configuration extracted from the config, if available.
         characterizer_type (str): Type identifier for the characterizer, always "feature".
         return_criterion (ReturnCriterion): Criterion determining when to return results.
+        agent_to_agent_closest_dists_chunk_size (int | None): Number of agents to process per closest-distance chunk.
     """
 
     def __init__(self, config: DictConfig) -> None:
@@ -31,6 +32,7 @@ class BaseFeature(ABC):
         self.characterizer_type = "feature"
         self.return_criterion = ReturnCriterion[config.get("return_criterion", "critical").upper()]
         self.compute_agent_to_agent_closest_dists = config.get("compute_agent_to_agent_closest_dists", False)
+        self.agent_to_agent_closest_dists_chunk_size: int | None = config.get("chunk_size")
 
     @property
     def name(self) -> str:
@@ -43,11 +45,13 @@ class BaseFeature(ABC):
         return re.sub(r"(?<!^)([A-Z])", r" \1", self.__class__.__name__).lower()
 
     @abstractmethod
-    def compute(self, scenario: Scenario) -> ScenarioFeatures:
+    def compute(self, scenario: Scenario, *, chunk_size: int | None = None) -> ScenarioFeatures:
         """Compute features for a given scenario.
 
         Args:
             scenario (Scenario): The scenario data containing trajectories, road geometry, and metadata.
+            chunk_size (int | None): Number of agents to process per closest-distance chunk. If omitted, uses the
+                configured value or the shared closest-distance default.
 
         Returns:
             ScenarioFeatures: Computed features for the scenario.

--- a/src/characterization/features/individual_features.py
+++ b/src/characterization/features/individual_features.py
@@ -284,7 +284,7 @@ class IndividualFeatures(BaseFeature):
             ),
         )
 
-    def compute(self, scenario: Scenario) -> ScenarioFeatures:
+    def compute(self, scenario: Scenario, *, chunk_size: int | None = None) -> ScenarioFeatures:
         """Compute comprehensive scenario features including individual agent features.
 
         Args:
@@ -292,6 +292,8 @@ class IndividualFeatures(BaseFeature):
                 - agent_data: Agent positions, velocities, validity masks, and type information
                 - metadata: Scenario timestamps, stationary speed thresholds, and other parameters
                 - static_map_data: Map conflict points and road geometry information
+            chunk_size (int | None): Number of agents to process per closest-distance chunk. If omitted, uses the
+                configured value or the shared closest-distance default.
 
         Returns:
             ScenarioFeatures: Comprehensive feature object containing:
@@ -310,7 +312,13 @@ class IndividualFeatures(BaseFeature):
             agent_data = scenario.agent_data
             agent_trajectories = AgentTrajectoryMasker(agent_data.agent_trajectories)
             agent_positions = agent_trajectories.agent_xyz_pos
-            agent_to_agent_closest_dists = compute_agent_to_agent_closest_dists(agent_positions)
+            closest_distance_chunk_size = (
+                self.agent_to_agent_closest_dists_chunk_size if chunk_size is None else chunk_size
+            )
+            agent_to_agent_closest_dists = compute_agent_to_agent_closest_dists(
+                agent_positions,
+                chunk_size=closest_distance_chunk_size,
+            )
 
         return ScenarioFeatures(
             metadata=scenario.metadata,

--- a/src/characterization/features/interaction_features.py
+++ b/src/characterization/features/interaction_features.py
@@ -969,6 +969,7 @@ class InteractionFeatures(BaseFeature):
         scenario: Scenario,
         *,
         max_workers: int | None = None,
+        chunk_size: int | None = None,
     ) -> ScenarioFeatures:
         """Compute scenario features focused on agent-to-agent interactions.
 
@@ -980,6 +981,8 @@ class InteractionFeatures(BaseFeature):
                 - static_map_data: Map conflict points and precomputed distances for mTTCP analysis
             max_workers (int | None): Maximum number of worker processes for parallel computation.
                 Defaults to None, which uses the number of processors on the machine.
+            chunk_size (int | None): Number of agents to process per closest-distance chunk. If omitted, uses the
+                configured value or the shared closest-distance default.
 
         Returns:
             ScenarioFeatures: Feature object containing:
@@ -999,7 +1002,13 @@ class InteractionFeatures(BaseFeature):
             agent_data = scenario.agent_data
             agent_trajectories = AgentTrajectoryMasker(agent_data.agent_trajectories)
             agent_positions = agent_trajectories.agent_xyz_pos
-            agent_to_agent_closest_dists = compute_agent_to_agent_closest_dists(agent_positions)
+            closest_distance_chunk_size = (
+                self.agent_to_agent_closest_dists_chunk_size if chunk_size is None else chunk_size
+            )
+            agent_to_agent_closest_dists = compute_agent_to_agent_closest_dists(
+                agent_positions,
+                chunk_size=closest_distance_chunk_size,
+            )
 
         return ScenarioFeatures(
             metadata=scenario.metadata,

--- a/src/characterization/features/safeshift_features.py
+++ b/src/characterization/features/safeshift_features.py
@@ -48,6 +48,7 @@ class SafeShiftFeatures(BaseFeature):
         scenario: Scenario,
         *,
         max_workers: int | None = None,
+        chunk_size: int | None = None,
     ) -> ScenarioFeatures:
         """Compute comprehensive scenario features combining individual and interaction analysis.
 
@@ -62,6 +63,8 @@ class SafeShiftFeatures(BaseFeature):
             max_workers (int | None): Maximum number of worker processes for parallel computation
                 of interaction features. Defaults to None, which uses the number of processors
                 on the machine.
+            chunk_size (int | None): Number of agents to process per closest-distance chunk. If omitted, uses the
+                configured value or the shared closest-distance default.
 
         Returns:
             ScenarioFeatures: Comprehensive feature object containing:
@@ -95,7 +98,13 @@ class SafeShiftFeatures(BaseFeature):
                 scenario.metadata.ego_vehicle_index,
             )
         else:
-            agent_to_agent_closest_dists = compute_agent_to_agent_closest_dists(agent_positions)
+            closest_distance_chunk_size = (
+                self.agent_to_agent_closest_dists_chunk_size if chunk_size is None else chunk_size
+            )
+            agent_to_agent_closest_dists = compute_agent_to_agent_closest_dists(
+                agent_positions,
+                chunk_size=closest_distance_chunk_size,
+            )
 
         return ScenarioFeatures(
             metadata=scenario.metadata,

--- a/src/characterization/scorer/base_scorer.py
+++ b/src/characterization/scorer/base_scorer.py
@@ -40,6 +40,7 @@ class BaseScorer(ABC):
         self.max_critical_distance = self.config.get("max_critical_distance", 0.5)
         self.aggregated_score_weight = self.config.get("aggregated_score_weight", 0.5)
         self.reduce_distance_penalty = self.config.get("reduce_distance_penalty", False)
+        self.agent_to_agent_closest_dists_chunk_size: int | None = config.get("chunk_size")
 
         self.detections = FeatureDetections.from_dict(config.get("detections", None))
         self.weights = FeatureWeights.from_dict(config.get("weights", None))
@@ -68,13 +69,18 @@ class BaseScorer(ABC):
 
     @staticmethod
     def _get_agent_to_agent_closest_dists(
-        scenario: Scenario, scenario_features: ScenarioFeatures
+        scenario: Scenario,
+        scenario_features: ScenarioFeatures,
+        *,
+        chunk_size: int | None = None,
     ) -> NDArray[np.float32]:
         """Retrieves or computes the agent-to-agent closest distances.
 
         Args:
             scenario (Scenario): Scenario object containing agent information.
             scenario_features (ScenarioFeatures): ScenarioFeatures object containing precomputed distances.
+            chunk_size (int | None): Number of agents to process per closest-distance chunk. If omitted, the shared
+                closest-distance default is used.
 
         Returns:
             NDArray[np.float32]: The agent-to-agent closest distances.
@@ -84,7 +90,7 @@ class BaseScorer(ABC):
             agent_data = scenario.agent_data
             agent_trajectories = AgentTrajectoryMasker(agent_data.agent_trajectories)
             agent_positions = agent_trajectories.agent_xyz_pos
-            agent_to_agent_dists = compute_agent_to_agent_closest_dists(agent_positions)
+            agent_to_agent_dists = compute_agent_to_agent_closest_dists(agent_positions, chunk_size=chunk_size)
 
         return np.nan_to_num(agent_to_agent_dists, nan=np.inf)
 
@@ -108,6 +114,7 @@ class BaseScorer(ABC):
         vru_priority_weight: float = 1.0,
         *,
         reduce_distance_penalty: bool = False,
+        chunk_size: int | None = None,
     ) -> NDArray[np.float32]:
         """Computes the weights for scoring based on the scenario and features, with respect to the ego agent.
 
@@ -120,6 +127,8 @@ class BaseScorer(ABC):
             max_critical_distance (float): Maximum critical distance to cap the weight.
             vru_priority_weight (float): Weight multiplier for vulnerable road users.
             reduce_distance_penalty (bool): Whether to reduce the distance penalty by taking the square root.
+            chunk_size (int | None): Number of agents to process per closest-distance chunk. If omitted, the shared
+                closest-distance default is used.
 
         Returns:
             NDArray[np.float32]: The computed weights for each agent.
@@ -131,7 +140,9 @@ class BaseScorer(ABC):
         agent_to_ego_dists = scenario_features.agent_to_ego_closest_dists
         if agent_to_ego_dists is None:
             agent_to_agent_dists = BaseScorer._get_agent_to_agent_closest_dists(
-                scenario, scenario_features
+                scenario,
+                scenario_features,
+                chunk_size=chunk_size,
             )  # Shape (num_agents, num_agents)
             min_dist = agent_to_agent_dists[:, ego_agent_index]
         else:
@@ -161,6 +172,7 @@ class BaseScorer(ABC):
         vru_priority_weight: float = 1.0,
         *,
         reduce_distance_penalty: bool = False,
+        chunk_size: int | None = None,
     ) -> NDArray[np.float32]:
         """Computes the weights for scoring based on the scenario and features, with respect to relevant agents.
 
@@ -173,12 +185,16 @@ class BaseScorer(ABC):
             max_critical_distance (float): Maximum critical distance to cap the weight.
             vru_priority_weight (float): Weight multiplier for vulnerable road users.
             reduce_distance_penalty (bool): Whether to reduce the distance penalty by taking the square root.
+            chunk_size (int | None): Number of agents to process per closest-distance chunk. If omitted, the shared
+                closest-distance default is used.
 
         Returns:
             NDArray[np.float32]: The computed weights for each agent.
         """
         agent_to_agent_dists = BaseScorer._get_agent_to_agent_closest_dists(
-            scenario, scenario_features
+            scenario,
+            scenario_features,
+            chunk_size=chunk_size,
         )  # Shape (num_agents, num_agents)
 
         # Determine the weights of the relevant agents, if the agent relevance is not provided, use uniform weights.
@@ -293,6 +309,7 @@ class BaseScorer(ABC):
                     max_critical_distance=self.max_critical_distance,
                     vru_priority_weight=self.vru_priority_weight,
                     reduce_distance_penalty=self.reduce_distance_penalty,
+                    chunk_size=self.agent_to_agent_closest_dists_chunk_size,
                 )
             case ScoreWeightingMethod.DISTANCE_TO_RELEVANT_AGENTS:
                 return BaseScorer._get_weights_wrt_relevant_agents(
@@ -301,6 +318,7 @@ class BaseScorer(ABC):
                     max_critical_distance=self.max_critical_distance,
                     vru_priority_weight=self.vru_priority_weight,
                     reduce_distance_penalty=self.reduce_distance_penalty,
+                    chunk_size=self.agent_to_agent_closest_dists_chunk_size,
                 )
             case _:
                 error_message = f"Unknown score weighting method: {self.score_weighting_method}"

--- a/src/characterization/utils/common.py
+++ b/src/characterization/utils/common.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from enum import Enum
 from itertools import pairwise
-from typing import Annotated, Any, ClassVar
+from typing import Annotated, Any, ClassVar, Final
 
 import numpy as np
 from natsort import natsorted
@@ -12,6 +12,7 @@ from characterization.utils.scenario_types import AgentType
 
 EPSILON = 1e-6
 LARGE_VALUE = 1e6
+DEFAULT_AGENT_TO_AGENT_CLOSEST_DISTS_CHUNK_SIZE: Final[int] = 8
 SUPPORTED_SCENARIO_TYPES = ["gt", "ho"]
 SUPPORTED_CRITERIA = ["critical", "average"]
 MIN_VALID_POINTS = 2

--- a/src/characterization/utils/geometric_utils.py
+++ b/src/characterization/utils/geometric_utils.py
@@ -6,7 +6,12 @@ from numpy.typing import NDArray
 from scipy.signal import resample
 
 from characterization.schemas.scenario import Scenario
-from characterization.utils.common import EPSILON, MIN_VALID_POINTS, AgentTrajectoryMasker
+from characterization.utils.common import (
+    DEFAULT_AGENT_TO_AGENT_CLOSEST_DISTS_CHUNK_SIZE,
+    EPSILON,
+    MIN_VALID_POINTS,
+    AgentTrajectoryMasker,
+)
 
 
 def get_polyline_dir(polyline: NDArray[np.float32]) -> NDArray[np.float32]:
@@ -69,13 +74,14 @@ def compute_dists_to_conflict_points(
 def compute_agent_to_agent_closest_dists(
     positions: NDArray[np.float32],
     *,
-    chunk_size: int = 256,
+    chunk_size: int | None = None,
 ) -> NDArray[np.float32]:
     """Computes the closest distance between each agent and any other agent over their trajectories.
 
     Args:
         positions: Array of agent positions over time with shape [num_agents, num_time_steps, 3].
-        chunk_size: Number of agents to process per chunk. Smaller values reduce peak memory usage. Defaults to 256.
+        chunk_size: Number of agents to process per chunk. Smaller values reduce peak memory usage. If omitted, the
+            shared closest-distance default is used.
 
     Returns:
         Minimum distance from each agent to every other agent over time with shape [num_agents, num_agents]. NaN values
@@ -84,6 +90,7 @@ def compute_agent_to_agent_closest_dists(
     Raises:
         ValueError: If ``chunk_size`` is not positive.
     """
+    chunk_size = DEFAULT_AGENT_TO_AGENT_CLOSEST_DISTS_CHUNK_SIZE if chunk_size is None else chunk_size
     if chunk_size <= 0:
         error_message = f"chunk_size must be positive; got {chunk_size}."
         raise ValueError(error_message)

--- a/src/characterization/utils/viz/animated_scenario.py
+++ b/src/characterization/utils/viz/animated_scenario.py
@@ -105,23 +105,23 @@ class AnimatedScenarioVisualizer(BaseVisualizer):
         Returns:
             Path: The path to the saved visualization file.
         """
-        scenario_id = scenario.metadata.scenario_id
-        suffix = "" if scores is None or scores.scene_score is None else f"_{round(scores.scene_score, 2)}"
-        output_filepath = output_dir / f"{scenario_id}{suffix}.gif"
+        scenario_id: str = scenario.metadata.scenario_id
+        suffix: str = "" if scores is None or scores.scene_score is None else f"_{round(scores.scene_score, 2)}"
+        output_filepath: Path = output_dir / f"{scenario_id}{suffix}.gif"
 
-        timestamp_seconds = scenario.metadata.timestamps_seconds
-        scenario_fps = min(self.fps, scenario.metadata.frequency_hz)
-        total_timesteps = scenario.metadata.track_length
-        total_time = timestamp_seconds[-1] - timestamp_seconds[0]
-        num_frames = scenario_fps * total_time * self.time_scale_factor
-        step_size = max(1, total_timesteps // int(num_frames))
+        timestamp_seconds: list[float] = scenario.metadata.timestamps_seconds
+        scenario_fps: float = min(self.fps, scenario.metadata.frequency_hz)
+        total_timesteps: int = scenario.metadata.track_length
+        total_time: float = timestamp_seconds[-1] - timestamp_seconds[0]
+        num_frames: int = max(1, int(scenario_fps * total_time * self.time_scale_factor))
+        step_size: int = max(1, total_timesteps // num_frames)
 
         logger.info(
             "Saving scenario to %s [Num. timesteps: %d, Total time: %.2fs, Generating ~%d frames with step size %d]",
             output_filepath,
             total_timesteps,
             total_time,
-            int(num_frames),
+            num_frames,
             step_size,
         )
 

--- a/tests/test_geometric_utils.py
+++ b/tests/test_geometric_utils.py
@@ -26,6 +26,9 @@ class ClosestDistanceTest(unittest.TestCase):
         dense_distances = np.linalg.norm(positions[:, np.newaxis, :] - positions[np.newaxis, :, :], axis=-1)
         expected = np.nan_to_num(np.nanmin(dense_distances, axis=-1), nan=np.inf).astype(np.float32)
 
+        actual_default = compute_agent_to_agent_closest_dists(positions)
+        np.testing.assert_array_equal(actual_default, expected)
+
         for chunk_size in (1, 2, 256):
             actual = compute_agent_to_agent_closest_dists(positions, chunk_size=chunk_size)
             np.testing.assert_array_equal(actual, expected)


### PR DESCRIPTION
## Summary

This change makes closest-distance computation memory-bounded and configurable across feature extraction and scoring, and prevents short scenario animations from failing with a division-by-zero error.

## Changes

- Add configurable `chunk_size` propagation through:
  - feature extraction;
  - interaction and SafeShift feature computation;
  - distance-based scorer weighting.
- Set the default closest-distance chunk size to `8`, reducing peak temporary memory usage while preserving the existing output shape and semantics.
- Retain keyword-only overrides for callers requiring a different chunk size.
- Preserve explicit rejection of non-positive chunk sizes.
- Clamp the animation frame count to at least one before calculating `step_size`, preventing division by zero for short scenarios.
- Report the clamped frame count in the animation log message.

## Impact

- Closest-distance results remain unchanged; only the size of intermediate allocations and the default processing granularity change.
- Larger chunk sizes remain available when throughput is preferable to lower peak memory usage.
- Scenarios whose requested animation frame count is less than one now produce a valid single-frame animation rather than raising `ZeroDivisionError.

## Validation

- `.venv/bin/python -m unittest discover -v`